### PR TITLE
BUG: resolve directory already exists failure

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ register_subs() {
 # Apply SElinux policies
 apply_selinux_policy() {
     sudo semanage fcontext -a -t container_runtime_exec_t /usr/local/bin/microshift
-    sudo mkdir /var/lib/kubelet/
+    sudo mkdir -p /var/lib/kubelet/
     sudo chcon -R -t container_file_t /var/lib/kubelet/
 }
 

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,8 @@ register_subs() {
 
 # Apply SElinux policies
 apply_selinux_policy() {
-    sudo semanage fcontext -a -t container_runtime_exec_t /usr/local/bin/microshift
+    sudo semanage fcontext -a -t container_runtime_exec_t /usr/local/bin/microshift ||
+      sudo semanage fcontext -m -t container_runtime_exec_t /usr/local/bin/microshift
     sudo mkdir -p /var/lib/kubelet/
     sudo chcon -R -t container_file_t /var/lib/kubelet/
 }


### PR DESCRIPTION
when running install.sh more than once to get a dev environment going, I encountered the following error causing the script to abort.

Error:
```sh
mkdir: cannot create directory ‘/var/lib/kubelet/’: File exists
```