### PR TITLE
BUG: remove append flag from systemd microshift.service file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -95,7 +95,7 @@ get_microshift() {
 
     apply_selinux_policy
 
-    cat << EOF | sudo tee -a /usr/lib/systemd/system/microshift.service
+    cat << EOF | sudo tee /usr/lib/systemd/system/microshift.service
 [Unit]
 Description=Microshift
 


### PR DESCRIPTION
running install.sh more than once results in the service file being appended rather than replaced causing the failure:

```sh
Failed to start microshift.service: Unit microshift.service has a bad unit file setting.
See system logs and 'systemctl status microshift.service' for details.
[root@rhel-n01 microshift]# systemctl status microshift.service
● microshift.service - Microshift
   Loaded: bad-setting (Reason: Unit microshift.service has a bad unit file setting.)
   Active: failed (Result: exit-code) since Tue 2021-06-15 19:07:35 EDT; 12min ago
 Main PID: 873 (code=exited, status=203/EXEC)

Jun 15 19:07:35 rhel-n01.fly.lab systemd[1]: microshift.service: Main process exited, code=exited, status=203/EXEC
Jun 15 19:07:35 rhel-n01.fly.lab systemd[1]: microshift.service: Failed with result 'exit-code'.
Jun 15 19:07:35 rhel-n01.fly.lab systemd[1]: microshift.service: Service RestartSec=100ms expired, scheduling restart.
Jun 15 19:07:35 rhel-n01.fly.lab systemd[1]: microshift.service: Scheduled restart job, restart counter is at 5.
Jun 15 19:07:35 rhel-n01.fly.lab systemd[1]: Stopped Microshift.
Jun 15 19:07:35 rhel-n01.fly.lab systemd[1]: microshift.service: Start request repeated too quickly.
Jun 15 19:07:35 rhel-n01.fly.lab systemd[1]: microshift.service: Failed with result 'exit-code'.
Jun 15 19:07:35 rhel-n01.fly.lab systemd[1]: Failed to start Microshift.
Jun 15 19:20:07 rhel-n01.fly.lab systemd[1]: microshift.service: Service has more than one ExecStart= setting, which is only allowed for Type=oneshot services.
```