### PR TITLE
Update OWNERS to be valid YAML

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,5 @@
-rootfs
-fzdarsky
-oglok
-copejon
+approvers:
+- rootfs
+- fzdarsky
+- oglok
+- copejon


### PR DESCRIPTION
OWNERS is supposed to be YAML of a certain format, invalid OWNERS causes noise in Prow logs. The `verify-owners` [plugin](https://github.com/openshift/release/blob/master/core-services/prow/02_config/redhat-et/microshift/_pluginconfig.yaml#L6) would protect you if you added the file in a PR, but not when it was directly committed and pushed.