### PR TITLE
refactor containerized microshift build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GO_LD_EXTRAFLAGS :=-X k8s.io/component-base/version.gitMajor=1 \
 # These tags make sure we can statically link and avoid shared dependencies
 GO_BUILD_FLAGS :=-tags 'include_gcs include_oss containers_image_openpgp gssapi providerless netgo osusergo'
 
-OUTPUT_DIR :=_output
+OUTPUT_DIR :=$(shell pwd)/_output
 CROSS_BUILD_BINDIR :=$(OUTPUT_DIR)/bin
 
 # targets "all:" and "build:" defined in vendor/github.com/openshift/build-machinery-go/make/targets/golang/build.mk
@@ -81,9 +81,10 @@ cross-build: cross-build-darwin-amd64 cross-build-linux-amd64 cross-build-linux-
 	$(CTR_CMD) build -t $(BUILD_IMAGE) -f $(BUILD_CFG) ./images
 
 .PHONY: build-containerized-microshift
-build-containerized-microshift: WHAT=build
-build-containerized-microshift: .init
-	$(CTR_CMD) run -v $(CACHE_VOL):/mnt/cache -v $(SRC_ROOT):/opt/app-root/src/github.com/redhat-et/microshift:z $(BUILD_IMAGE) build
+build-containerized-microshift:
+	$(CTR_CMD) build -t microshift -f $(BUILD_CFG) .
+	mkdir -p $(CROSS_BUILD_BINDIR)/linux_amd64
+	$(CTR_CMD) cp $(shell $(CTR_CMD) create --rm microshift):/usr/bin/microshift $(CROSS_BUILD_BINDIR)/linux_amd64/microshift
 
 .PHONY: build-containerized-cross-build-darwin-amd64
 build-containerized-cross-build-darwin-amd64: .init

--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -1,11 +1,38 @@
-FROM registry.access.redhat.com/ubi8/go-toolset
+FROM registry.access.redhat.com/ubi8/go-toolset as build
+
 USER root
+
 LABEL name=microshift-build
 
 ENV GOPATH=/opt/app-root GOCACHE=/mnt/cache GO111MODULE=on
 
 WORKDIR $GOPATH/src/github.com/redhat-et/microshift
 
-RUN yum install gpgme-devel glibc-static libassuan-devel -y
+RUN yum install glibc-static -y
 
-ENTRYPOINT ["make"]
+COPY . .
+
+RUN make clean build
+
+# Containerized microshift
+# To start:
+# podman run --privileged --ipc=host --network=host  \
+# -v /var/run:/var/run \
+# -v /sys:/sys:ro \
+# -v /var/lib:/var/lib:rw,rshared \
+# -v /lib/modules:/lib/modules \
+# -v /etc:/etc \
+# -v /run/containers:/run/containers \
+# -v /var/log:/var/log   microshift
+
+FROM  registry.access.redhat.com/ubi8/ubi
+
+RUN yum install -y \
+    policycoreutils-python-utils \
+    iptables
+
+RUN yum clean all -y
+
+COPY --from=build /opt/app-root/src/github.com/redhat-et/microshift/microshift /usr/bin/microshift
+
+ENTRYPOINT ["/usr/bin/microshift", "run"]


### PR DESCRIPTION
This PR standarizes the build flow for `make microshift` target so that the containerized microshift binary and the binary produced by the containerized build are known to be identical.  This is accomplished by first building the binary in the build container, copying it to the runnable image, and then copying it to the host.

Contingent on #115, as that defines a stable container runtime env.