### PR TITLE
Adds log-level flag with default to info

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -23,6 +23,26 @@ func NewRunMicroshiftCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
+
+	// get the log level
+        flags.StringVar(&logLevel, "log-level", "info", "Set the log level for Microshift (default: info)")
+        if logLevel == "trace" {
+                logrus.SetLevel(logrus.TraceLevel)
+        } else if logLevel == "debug" {
+                logrus.SetLevel(logrus.DebugLevel)
+        } else if logLevel == "warn" {
+                logrus.SetLevel(logrus.WarnLevel)
+        } else if logLevel == "error" {
+                logrus.SetLevel(logrus.ErrorLevel)
+        } else if logLevel == "fatal" {
+                logrus.SetLevel(logrus.FatalLevel)
+        } else if logLevel == "panic" {
+                logrus.SetLevel(logrus.PanicLevel)
+        } else {
+                // default to info
+                logrus.SetLevel(logrus.InfoLevel)
+        }
+
 	// Read the config flag directly into the struct, so it's immediately available.
 	flags.StringVar(&cfg.ConfigFile, "config", cfg.ConfigFile, "File to read configuration from.")
 	cmd.MarkFlagFilename("config", "yaml", "yml")

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -13,7 +13,7 @@ import (
 
 func NewRunMicroshiftCommand() *cobra.Command {
 	cfg := config.NewMicroshiftConfig()
-
+	var logLevel string
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run Microshift",

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -23,26 +23,24 @@ func NewRunMicroshiftCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-
 	// get the log level
-        flags.StringVar(&logLevel, "log-level", "info", "Set the log level for Microshift (default: info)")
-        if logLevel == "trace" {
-                logrus.SetLevel(logrus.TraceLevel)
-        } else if logLevel == "debug" {
-                logrus.SetLevel(logrus.DebugLevel)
-        } else if logLevel == "warn" {
-                logrus.SetLevel(logrus.WarnLevel)
-        } else if logLevel == "error" {
-                logrus.SetLevel(logrus.ErrorLevel)
-        } else if logLevel == "fatal" {
-                logrus.SetLevel(logrus.FatalLevel)
-        } else if logLevel == "panic" {
-                logrus.SetLevel(logrus.PanicLevel)
-        } else {
-                // default to info
-                logrus.SetLevel(logrus.InfoLevel)
-        }
-
+	flags.StringVar(&logLevel, "log-level", "info", "Set the log level for Microshift (default: info)")
+	if logLevel == "trace" {
+		logrus.SetLevel(logrus.TraceLevel)
+	} else if logLevel == "debug" {
+		logrus.SetLevel(logrus.DebugLevel)
+	} else if logLevel == "warn" {
+		logrus.SetLevel(logrus.WarnLevel)
+	} else if logLevel == "error" {
+		logrus.SetLevel(logrus.ErrorLevel)
+	} else if logLevel == "fatal" {
+		logrus.SetLevel(logrus.FatalLevel)
+	} else if logLevel == "panic" {
+		logrus.SetLevel(logrus.PanicLevel)
+	} else {
+		// default to info
+		logrus.SetLevel(logrus.InfoLevel)
+	}
 	// Read the config flag directly into the struct, so it's immediately available.
 	flags.StringVar(&cfg.ConfigFile, "config", cfg.ConfigFile, "File to read configuration from.")
 	cmd.MarkFlagFilename("config", "yaml", "yml")


### PR DESCRIPTION
Addresses issue #91 and adds a `log-level` flag controlling the default logrus logging level. If the log level is set to something incorrect, logrus defaults to `InfoLevel`