### PR TITLE
Use ubi8-minimal instead of regular ubi8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,11 @@
 # -v /run/containers:/run/containers \
 # -v /var/log:/var/log   microshift
 
-FROM  registry.access.redhat.com/ubi8/ubi
-RUN yum install -y \
-    policycoreutils-python-utils \
-    conntrack \
-    iptables-services || yum clean all -y
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+RUN microdnf install -y \
+      policycoreutils-python-utils \
+      conntrack \
+      iptables-services && \
+    microdnf clean all
 ADD _output/bin/microshift /microshift
 ENTRYPOINT ["/microshift", "run"]

--- a/hack/all-in-one/Dockerfile
+++ b/hack/all-in-one/Dockerfile
@@ -1,15 +1,24 @@
 FROM fedora:33
-RUN dnf module -y enable cri-o:1.20 && dnf install -y cri-o cri-tools
-RUN dnf install -y conntrack \
-    iptables-services \ 
-    iproute \
-    procps-ng
-RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && chmod +x ./kubectl && mv ./kubectl /usr/local/bin/kubectl
-ADD microshift /usr/local/bin/microshift
-ADD unit /usr/lib/systemd/system/microshift.service
-ADD kubelet-cgroups.conf /etc/systemd/system.conf.d/kubelet-cgroups.conf
-RUN sed -i 's/10.85.0.0\/16/10.42.0.0\/24/' /etc/cni/net.d/100-crio-bridge.conf
-RUN sed -i 's/0.3.1/0.4.0/' /etc/cni/net.d/100-crio-bridge.conf
-RUN systemctl enable microshift.service
-RUN systemctl enable crio 
+
+COPY microshift /usr/local/bin/microshift
+COPY unit /usr/lib/systemd/system/microshift.service
+COPY kubelet-cgroups.conf /etc/systemd/system.conf.d/kubelet-cgroups.conf
+
+RUN dnf module -y enable cri-o:1.20 && \
+    dnf install -y cri-o \
+        cri-tools \
+        conntrack \
+        iptables-services \ 
+        iproute \
+        procps-ng && \
+    dnf clean all
+
+RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin/kubectl && \
+    sed -i 's/10.85.0.0\/16/10.42.0.0\/24/' /etc/cni/net.d/100-crio-bridge.conf && \
+    sed -i 's/0.3.1/0.4.0/' /etc/cni/net.d/100-crio-bridge.conf && \
+    systemctl enable microshift.service && \
+    systemctl enable crio 
+
 CMD [ "/sbin/init" ]

--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -25,13 +25,12 @@ RUN make clean build
 # -v /run/containers:/run/containers \
 # -v /var/log:/var/log   microshift
 
-FROM  registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
-RUN yum install -y \
-    policycoreutils-python-utils \
-    iptables
-
-RUN yum clean all -y
+RUN microdnf install -y \
+      policycoreutils-python-utils \
+      iptables && \
+    microdnf clean all
 
 COPY --from=build /opt/app-root/src/github.com/redhat-et/microshift/microshift /usr/bin/microshift
 


### PR DESCRIPTION
It saves ~60 MB:

```
$ podman images | grep localhost
localhost/micro                              latest  548daf096454  35 seconds ago      335 MB
localhost/regular                            latest  c1d913e921fa  13 minutes ago      396 MB
```

Closes #141 