### PR TITLE
add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+about: Report a bug encountered while operating Microshift 
+labels: bug
+title: '[BUG] <title>'
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+-->
+
+
+#### What happened:
+
+#### What you expected to happen:
+
+#### How to reproduce it (as minimally and precisely as possible):
+
+1. '...'
+2. '...'
+
+#### Anything else we need to know?:
+
+
+#### Environment:
+- Microshift version (use `microshift version`):
+- Hardware configuration:
+- OS (e.g: `cat /etc/os-release`):
+- Kernel (e.g. `uname -a`):
+- Others:
+
+#### Log bundle
+<!-- A link to bootstrap log bundle or `oc adm must-gather` archive.-->
+

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -29,6 +29,6 @@ title: '[BUG] <title>'
 - Kernel (e.g. `uname -a`):
 - Others:
 
-#### Log bundle
-<!-- A link to bootstrap log bundle or `oc adm must-gather` archive.-->
+#### Relevant Logs 
+
 

--- a/.github/ISSUE_TEMPLATE/enhancement-tracking.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-tracking.md
@@ -12,8 +12,10 @@ A proposal that works through the design along with the implications of the chan
 -->
 #### Design Document Link
 
-PR: #<PR>
+PR: #<PR Number>
 
 #### What would you like to be added:
 
 #### Why is this needed:
+
+

--- a/.github/ISSUE_TEMPLATE/enhancement-tracking.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-tracking.md
@@ -1,0 +1,19 @@
+---
+name: Enhancement Tracking Issue
+about: Provide supporting details for a feature in development
+labels: feature
+title: '[Enhancement]: <title>'
+
+---
+<!-- Feature requests are unlikely to make progress as an issue.
+
+A proposal that works through the design along with the implications of the change should be submitted as a design document in https://github.com/redhat-et/microshift/tree/main/doc/design/
+
+-->
+#### Design Document Link
+
+PR: #<PR>
+
+#### What would you like to be added:
+
+#### Why is this needed:

--- a/.github/ISSUE_TEMPLATE/enhancement-tracking.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-tracking.md
@@ -7,7 +7,7 @@ title: '[Enhancement]: <title>'
 ---
 <!-- Feature requests are unlikely to make progress as an issue.
 
-A proposal that works through the design along with the implications of the change should be submitted as a design document in https://github.com/redhat-et/microshift/tree/main/doc/design/
+A proposal that works through the design along with the implications of the change should be submitted as a design document in https://github.com/redhat-et/microshift/tree/main/docs/design/
 
 -->
 #### Design Document Link

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
-'<!--  Thanks for sending a pull request!  Here are some tips for you:
+<!--  Thanks for sending a pull request!  Here are some tips for you:
 If this is your first contribution, read our Contributing guide https://github.com/redhat-et/microshift/CONTRIBUTING.md
 If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
 -->
-**Which issue(s) this PR fixes**:
+**Which issue(s) this PR addresses**:
 <!--
 *Automatically closes linked issue when PR is merged.
-Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
 -->
-Fixes #'
+Closes #<Issue Number>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+'<!--  Thanks for sending a pull request!  Here are some tips for you:
+If this is your first contribution, read our Contributing guide https://github.com/redhat-et/microshift/CONTRIBUTING.md
+If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
+-->
+**Which issue(s) this PR fixes**:
+<!--
+*Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+-->
+Fixes #'


### PR DESCRIPTION
Adds PR and Issue templates in the hopes of standardizing user and contributor submissions.  See https://github.com/openshift/okd/issues/new/choose as an example.

Submitters may still open an blank git issue, but this can be toggled off if we choose.

Fixes #166 