### PR TITLE
add kubeconfig for cluster and public access

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -160,6 +160,12 @@ func initKubeconfig(cfg *config.MicroshiftConfig) error {
 	if err := util.Kubeconfig(cfg.DataDir+"/resources/kubeadmin/kubeconfig", "system:admin", []string{"system:masters"}, cfg.Cluster.URL); err != nil {
 		return err
 	}
+	if err := util.Kubeconfig(cfg.DataDir+"/resources/kubeadmin/kubeconfig.public", "system:admin", []string{"system:masters"}, cfg.Cluster.PublicURL); err != nil {
+		return err
+	}
+	if err := util.Kubeconfig(cfg.DataDir+"/resources/kubeadmin/kubeconfig", "system:admin", []string{"system:masters"}, cfg.Cluster.URL); err != nil {
+		return err
+	}
 	if err := util.Kubeconfig(cfg.DataDir+"/resources/kube-apiserver/kubeconfig", "kube-apiserver", []string{"kube-apiserver", "system:kube-apiserver", "system:masters"}, cfg.Cluster.URL); err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,8 +29,10 @@ var (
 )
 
 type ClusterConfig struct {
+	// URL is api endpoint accessed by local host
 	URL string `yaml:"url"`
-
+	// PublicURL is api endpoint accessed external hosts
+	PublicURL   string `yaml:"publicUrl"`
 	ClusterCIDR string `yaml:"clusterCIDR"`
 	ServiceCIDR string `yaml:"serviceCIDR"`
 	DNS         string `yaml:"dns"`
@@ -86,6 +88,7 @@ func NewMicroshiftConfig() *MicroshiftConfig {
 		HostIP:          hostIP,
 		Cluster: ClusterConfig{
 			URL:         "https://127.0.0.1:6443",
+			PublicURL:   "https://" + hostIP + ":6443",
 			ClusterCIDR: "10.42.0.0/16",
 			ServiceCIDR: "10.43.0.0/16",
 			DNS:         "10.43.0.10",


### PR DESCRIPTION
Currently kubeadmin kubeconfig points to `127.0.0.1`. This IP doesn't work outside of the localhost.