### PR TITLE
Use k8s compliant build date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,12 @@
 include ./vendor/github.com/openshift/build-machinery-go/make/golang.mk
 include ./vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps.mk
 
-TIMESTAMP :=$(shell date -u +'%Y-%m-%d-%H%M%S')
+# TIMESTAMP is defined here, and only here, and propagated through out the build flow.  This ensures that every artifact
+# (binary version and image tag) all have the exact same build timestamp.  Because kubectl/oc expect
+# a timestamp composed with ':'s we must replace the chars with '-' so that it is still compliant with image tag format.
+BIN_TIMESTAMP :=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+TIMESTAMP :=$(shell echo $(BIN_TIMESTAMP) | tr ':' '-')
+
 RELEASE_PRE :=0.4.7-0.microshift
 SOURCE_GIT_TAG :=$(shell echo $(RELEASE_PRE)-$(TIMESTAMP))
 
@@ -21,13 +26,13 @@ GO_LD_EXTRAFLAGS :=-X k8s.io/component-base/version.gitMajor=1 \
                    -X k8s.io/component-base/version.gitVersion=v1.20.1 \
                    -X k8s.io/component-base/version.gitCommit=5feb30e1bd3620 \
                    -X k8s.io/component-base/version.gitTreeState=clean \
-                   -X k8s.io/component-base/version.buildDate=$(TIMESTAMP) \
+                   -X k8s.io/component-base/version.buildDate=$(BIN_TIMESTAMP) \
                    -X k8s.io/client-go/pkg/version.gitMajor=1 \
                    -X k8s.io/client-go/pkg/version.gitMinor=20 \
                    -X k8s.io/client-go/pkg/version.gitVersion=v1.20.1 \
                    -X k8s.io/client-go/pkg/version.gitCommit=5feb30e1bd3620 \
                    -X k8s.io/client-go/pkg/version.gitTreeState=clean \
-                   -X k8s.io/client-go/pkg/version.buildDate=$(TIMESTAMP) \
+                   -X k8s.io/client-go/pkg/version.buildDate=$(BIN_TIMESTAMP) \
                    $(GO_EXT_LD_FLAGS) \
                    -s -w
 

--- a/Makefile
+++ b/Makefile
@@ -35,16 +35,17 @@ GO_LD_FLAGS :=-ldflags "-X k8s.io/component-base/version.gitMajor=1 \
                    -X k8s.io/client-go/pkg/version.gitCommit=5feb30e1bd3620 \
                    -X k8s.io/client-go/pkg/version.gitTreeState=clean \
                    -X k8s.io/client-go/pkg/version.buildDate=$(BIN_TIMESTAMP) \
-                   -X github.com/microshift/pkg/version.versionFromGit=$(SOURCE_GIT_TAG) \
-                   -X github.com/microshift/pkg/version.gitCommit=$(SOURCE_GIT_COMMIT) \
-                   -X github.com/microshift/pkg/version.gitTreeState=$(SOURCE_GIT_TREE_STATE) \
-                   -X github.com/microshift/pkg/version.buildDate=$(BIN_TIMESTAMP) \
+                   -X github.com/openshift/microshift/pkg/version.versionFromGit=$(SOURCE_GIT_TAG) \
+                   -X github.com/openshift/microshift/pkg/version.commitFromGit=$(SOURCE_GIT_COMMIT) \
+                   -X github.com/openshift/microshift/pkg/version.gitTreeState=$(SOURCE_GIT_TREE_STATE) \
+                   -X github.com/openshift/microshift/pkg/version.buildDate=$(BIN_TIMESTAMP) \
                    $(GO_EXT_LD_FLAGS) \
                    -s -w"
 
 debug:
 	@echo FLAGS:"$(GO_LD_FLAGS)"
 	@echo TAG:"$(SOURCE_GIT_TAG)"
+	@echo SOURCE_GIT_TAG:"$(SOURCE_GIT_TAG)"
 
 # These tags make sure we can statically link and avoid shared dependencies
 GO_BUILD_FLAGS :=-tags 'include_gcs include_oss containers_image_openpgp gssapi providerless netgo osusergo'

--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -1,12 +1,9 @@
-# DIGEST is the registry.access.redhat.com/ubi8/ubi-minimal:8.4 architecture specific image to use for the run stage
-# When specifying, assign as "@sha256: ... ".  Unset by default
-ARG DIGEST
-
 # Build stage
 FROM registry.access.redhat.com/ubi8/go-toolset as builder
 
 ARG ARCH=amd64
 ARG MAKE_TARGET=cross-build-linux-$ARCH
+ARG BIN_TIMESTAMP
 ARG SOURCE_GIT_TAG
 
 USER root
@@ -21,7 +18,7 @@ RUN yum install glibc-static -y
 
 COPY . .
 
-RUN make clean $MAKE_TARGET SOURCE_GIT_TAG=$SOURCE_GIT_TAG
+RUN make clean $MAKE_TARGET SOURCE_GIT_TAG=$SOURCE_GIT_TAG BIN_TIMESTAMP=$BIN_TIMESTAMP
 
 # Run stage
 # Containerized microshift


### PR DESCRIPTION
Fixes #170 

The binary build datetime data must conform to k8s formating `%Y-%m-%dT%H:%M:%SZ`.  However, the image artifacts tags must not have ':'s, so we replace them with '-'.  The image tags will change slightly to e.g. `quay.io/microshift/microshift:0.4.7-0.microshift-2021-07-22T19-13-14Z-linux-amd64`.



`kubectl version -o yaml`:
```
[root@fedora microshift]# oc version -o yaml
clientVersion:
  buildDate: "2021-06-25T21:59:29Z"
  compiler: gc
  gitCommit: 8b4b09487463415374368af3bbc4ff2e6366477b
  gitTreeState: clean
  gitVersion: 4.7.0-202106252127.p0.git.8b4b094-8b4b094
  goVersion: go1.15.7
  major: ""
  minor: ""
  platform: linux/amd64
releaseClientVersion: 4.7.19
serverVersion:
  buildDate: "2021-07-22T23:55:38Z" <---- this is the value affected by the change described above
  compiler: gc
  gitCommit: 5feb30e1bd3620
  gitTreeState: clean
  gitVersion: v1.20.1
  goVersion: go1.16.3
  major: "1"
  minor: "20"
  platform: linux/amd64
```

This PR also address `microshift version -o yaml` printing the incorrect gitCommit and gitTreeState.

The issue was that the included build-machinery-go make files a) always set the values globally first when make is run and b) are configured for semver schemes.  To work around this, some initialization was changed to override the variables (SOURCE_GIT_TAG and SOURCE_GIT_TREE_STATE).  The logic that generates the var values is nearly identical to build-machinery-go's, but adjusted to read our version scheme.

This does not affect releases because the SOURCE_GIT_TAG is overridden by the release.sh with a developer-provided tag.  The pattern appended on dirty git trees is set by `git describe`, see https://git-scm.com/docs/git-describe#_examples

e.g.
`0.4.7-0.microshift-2021-07-07-002815-10-gb78e79c`, where 10 == number of commits ahead or behind the tag `0.4.7-0.microshift-2021-07-07-002815`, and `(-g)b78e79c`  denoting the abbreviated commit of HEAD.