### PR TITLE
unify service account key and signing keys

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -77,10 +77,6 @@ func initCerts(cfg *config.MicroshiftConfig) error {
 		"service-account.crt", "service-account.key"); err != nil {
 		return err
 	}
-	if err := util.GenKeys(cfg.DataDir+"/resources/kube-apiserver/secrets/service-account-signing-key",
-		"service-account.crt", "service-account.key"); err != nil {
-		return err
-	}
 	if err := util.GenCerts("system:masters", cfg.DataDir+"/certs/kube-apiserver/secrets/aggregator-client",
 		"tls.crt", "tls.key",
 		[]string{"system:admin", "system:masters"}); err != nil {

--- a/pkg/controllers/kube-api.go
+++ b/pkg/controllers/kube-api.go
@@ -100,7 +100,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) {
 		"--requestheader-username-headers=X-Remote-User",
 		"--service-account-issuer=https://kubernetes.svc",
 		"--service-account-key-file=" + cfg.DataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.key",
-		"--service-account-signing-key-file=" + cfg.DataDir + "/resources/kube-apiserver/secrets/service-account-signing-key/service-account.key",
+		"--service-account-signing-key-file=" + cfg.DataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.key",
 		"--service-cluster-ip-range=" + cfg.Cluster.ServiceCIDR,
 		"--storage-backend=etcd3",
 		"--tls-cert-file=" + cfg.DataDir + "/certs/kube-apiserver/secrets/service-network-serving-certkey/tls.crt",

--- a/pkg/controllers/kube-api.go
+++ b/pkg/controllers/kube-api.go
@@ -99,7 +99,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) {
 		"--requestheader-group-headers=X-Remote-Group",
 		"--requestheader-username-headers=X-Remote-User",
 		"--service-account-issuer=https://kubernetes.svc",
-		"--service-account-key-file=" + cfg.DataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.key",
+		"--service-account-key-file=" + cfg.DataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.crt",
 		"--service-account-signing-key-file=" + cfg.DataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.key",
 		"--service-cluster-ip-range=" + cfg.Cluster.ServiceCIDR,
 		"--storage-backend=etcd3",


### PR DESCRIPTION
fix #https://github.com/redhat-et/microshift/issues/175#issuecomment-884987918 

the root cause is that the kube-apiserver and kube-controller-mananger use different private keys for service account and service account tokens.

cc @tosin2013 