### PR TITLE
Initialize also with pre-existing data dir

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -56,14 +57,13 @@ func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 		logrus.Fatalf("Microshift must be run privileged for role 'node'")
 	}
 
-	// if data dir is missing, create and initialize it
+	os.MkdirAll(cfg.DataDir, 0700)
+	os.MkdirAll(cfg.LogDir, 0700)
+
 	// TODO: change to only initialize what is strictly necessary for the selected role(s)
-	if _, err := os.Stat(cfg.DataDir); errors.Is(err, os.ErrNotExist) {
-		os.MkdirAll(cfg.DataDir, 0700)
+	if _, err := os.Stat(filepath.Join(cfg.DataDir, "certs")); errors.Is(err, os.ErrNotExist) {
 		initAll(cfg)
 	}
-	// if log dir is missing, create it
-	os.MkdirAll(cfg.LogDir, 0700)
 
 	m := servicemanager.NewServiceManager()
 	if config.StringInList("controlplane", cfg.Roles) {


### PR DESCRIPTION
Currently, Microshift checks for the non-existence of the data dir (/var/lib/microshift) to infer that
it runs for the first time and thus should initialize certs, kubeconfigs, etc. This creates a problem
on systems where /var/lib/microshift already exists (e.g. for pre-loading of images or manifests).

Until we have cleaned-up initialization as part of the multi-node work, this patch introduces a work-
around that makes initialization conditional on the cert dir being present instead, which is more
specific.

Signed-off-by: Frank A. Zdarsky <fzdarsky@redhat.com>

Closes #189 
