### PR TITLE
Use systemd resolv.conf in case it exists

### DIFF
--- a/pkg/config/kubelet.go
+++ b/pkg/config/kubelet.go
@@ -16,6 +16,7 @@ limitations under the License.
 package config
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -60,6 +61,12 @@ featureGates:
   ServiceNodeExclusion: true
   SupportPodPidsLimit: true
 serverTLSBootstrap: false #TODO`)
+
+	// Load real resolv.conf in case systemd-resolved is used
+	// https://github.com/coredns/coredns/blob/master/plugin/loop/README.md#troubleshooting-loops-in-kubernetes-clusters
+	if _, err := os.Stat("/run/systemd/resolve/resolv.conf"); !errors.Is(err, os.ErrNotExist) {
+		data = append(data, "\nresolvConf: /run/systemd/resolve/resolv.conf"...)
+	}
 	os.MkdirAll(filepath.Dir(cfg.DataDir+"/resources/kubelet/config/config.yaml"), os.FileMode(0755))
 	return ioutil.WriteFile(cfg.DataDir+"/resources/kubelet/config/config.yaml", data, 0644)
 }


### PR DESCRIPTION
In hosts where resolv.conf is controlled by systemd-resolved, the file
/etc/resolv.conf contains only the localhost IP "127.0.0.53" that is
managed by systemd-resolved. The correct file with upstream servers
in this case is /run/systemd/resolve/resolv.conf that if exists
is appended to Kubelet config to be used on containers that use
"dnsPolicy: Default".

Signed-off-by: Carlos de Paula <me@carlosedp.com>
