### PR TITLE
retrieve platform specific microshift binary from release repo

### DIFF
--- a/hack/all-in-one/Dockerfile
+++ b/hack/all-in-one/Dockerfile
@@ -1,6 +1,10 @@
 FROM registry.access.redhat.com/ubi8/ubi-init:8.4
 
-COPY microshift /usr/local/bin/microshift
+RUN export VERSION=$(curl -s https://api.github.com/repos/redhat-et/microshift/releases | grep tag_name | head -n 1 | cut -d '"' -f 4) && \
+    export ARCH=$(uname -m |sed -e "s/x86_64/amd64/" |sed -e "s/aarch64/arm64/") && \
+    curl -LO https://github.com/redhat-et/microshift/releases/download/$VERSION/microshift-linux-${ARCH} && \
+    mv microshift-linux-${ARCH} /usr/local/bin/microshift && chmod 755 /usr/local/bin/microshift
+
 COPY unit /usr/lib/systemd/system/microshift.service
 COPY kubelet-cgroups.conf /etc/systemd/system.conf.d/kubelet-cgroups.conf
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/redhat-et/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Currently the AIO Dockerfile expects the microshift binary in current directory. This is no longer needed since recent release has both amd64 and arm64 support. This fix is to get platform specific binary in the Dockerfile, so we can use this to build a multi-arch image.
Closes #<Issue Number>
