### PR TITLE
build both cuda and ubi aio images

### DIFF
--- a/hack/all-in-one/Dockerfile
+++ b/hack/all-in-one/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-init:8.4
+ARG IMAGE_NAME=registry.access.redhat.com/ubi8/ubi-init:8.4
+FROM ${IMAGE_NAME}
 
 RUN export VERSION=$(curl -s https://api.github.com/repos/redhat-et/microshift/releases | grep tag_name | head -n 1 | cut -d '"' -f 4) && \
     export ARCH=$(uname -m |sed -e "s/x86_64/amd64/" |sed -e "s/aarch64/arm64/") && \

--- a/hack/all-in-one/build-images.sh
+++ b/hack/all-in-one/build-images.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+TAG="${TAG:-quay.io/microshift/microshift-aio-$(date +%Y-%m-%d-%H-%M)}"
+for i in "registry.access.redhat.com/ubi8/ubi-init:8.4" "docker.io/nvidia/cuda:11.4.1-cudnn8-devel-ubi8"; do
+   echo "build microshift aio image using base image "${i}
+   tag=$(echo ${i} |awk -F"/" '{print $NF}'| sed -e 's/:/-/g')
+   echo ${tag}
+   podman build --build-arg IMAGE_NAME=${i} -t ${TAG}-${tag} .
+done

--- a/hack/all-in-one/build-images.sh
+++ b/hack/all-in-one/build-images.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 TAG="${TAG:-quay.io/microshift/microshift-aio-$(date +%Y-%m-%d-%H-%M)}"
-for i in "registry.access.redhat.com/ubi8/ubi-init:8.4" "docker.io/nvidia/cuda:11.4.1-cudnn8-devel-ubi8"; do
+for i in "registry.access.redhat.com/ubi8/ubi-init:8.4" "docker.io/nvidia/cuda:11.4.2-base-ubi8"; do
    echo "build microshift aio image using base image "${i}
    tag=$(echo ${i} |awk -F"/" '{print $NF}'| sed -e 's/:/-/g')
    echo ${tag}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/redhat-et/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
kubelet vendors cadvisor, which vendors go-nvml. To make nvml run, we need to have libnvidia-ml.so on the node.
per cuda image, we need to have cuda-nvml-devel rpm.
```console
# rpm -qf /usr/local/cuda-11.4/targets/x86_64-linux/lib/stubs/libnvidia-ml.so
cuda-nvml-devel-11-4-11.4.43-1.x86_64
```