### PR TITLE
Support Ubuntu for install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e -o pipefail
 
 # Usage:
@@ -17,7 +17,7 @@ CONFIG_ENV_ONLY=${CONFIG_ENV_ONLY:=false}
 # Function to get Linux distribution
 get_distro() {
     DISTRO=$(egrep '^(ID)=' /etc/os-release| sed 's/"//g' | cut -f2 -d"=")
-    if [[ $DISTRO != @(rhel|fedora|centos) ]]
+    if [[ $DISTRO != @(rhel|fedora|centos|ubuntu) ]]
     then
       echo "This Linux distro is not supported by the install script"
       exit 1
@@ -40,7 +40,7 @@ register_subs() {
     then
         sudo subscription-manager register --auto-attach < /dev/tty
         POOL=$(sudo subscription-manager list --available --matches '*OpenShift' | grep Pool | head -n1 | awk -F: '{print $2}' | tr -d ' ')
-	sudo subscription-manager attach --pool $POOL
+        sudo subscription-manager attach --pool $POOL
         sudo subscription-manager config --rhsm.manage_repos=1
     fi
     set -e -o pipefail
@@ -63,23 +63,30 @@ build_selinux_policy() {
 
 # Install dependencies
 install_dependencies() {
-    sudo dnf install -y \
-    policycoreutils-python-utils \
-    conntrack \
-    firewalld 
+    if [ "$DISTRO" = "ubuntu" ]; then
+        sudo apt-get install -y \
+            policycoreutils-python-utils \
+            conntrack \
+            firewalld
+    else
+        sudo dnf install -y \
+            policycoreutils-python-utils \
+            conntrack \
+            firewalld
+    fi
 }
 
 # Establish Iptables rules
 establish_firewall () {
-sudo systemctl enable firewalld --now
-sudo firewall-cmd --zone=public --permanent --add-port=6443/tcp
-sudo firewall-cmd --zone=public --permanent --add-port=30000-32767/tcp
-sudo firewall-cmd --zone=public --permanent --add-port=2379-2380/tcp
-sudo firewall-cmd --zone=public --add-masquerade --permanent
-sudo firewall-cmd --zone=public --add-port=10250/tcp --permanent
-sudo firewall-cmd --zone=public --add-port=10251/tcp --permanent
-sudo firewall-cmd --permanent --zone=trusted --add-source=10.42.0.0/16
-sudo firewall-cmd --reload
+    sudo systemctl enable firewalld --now
+    sudo firewall-cmd --zone=public --permanent --add-port=6443/tcp
+    sudo firewall-cmd --zone=public --permanent --add-port=30000-32767/tcp
+    sudo firewall-cmd --zone=public --permanent --add-port=2379-2380/tcp
+    sudo firewall-cmd --zone=public --add-masquerade --permanent
+    sudo firewall-cmd --zone=public --add-port=10250/tcp --permanent
+    sudo firewall-cmd --zone=public --add-port=10251/tcp --permanent
+    sudo firewall-cmd --permanent --zone=trusted --add-source=10.42.0.0/16
+    sudo firewall-cmd --reload
 }
 
 
@@ -99,6 +106,21 @@ install_crio() {
         sudo curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/devel:kubic:libcontainers:stable.repo
         sudo curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:$CRIOVERSION.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:$CRIOVERSION/$OS/devel:kubic:libcontainers:stable:cri-o:$CRIOVERSION.repo
         sudo dnf install -y cri-o cri-tools
+      ;;
+      "ubuntu")
+        CRIOVERSION=1.20
+        OS=xUbuntu_20.04
+        echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/ /" > devel:kubic:libcontainers:stable.list
+        sudo mv devel:kubic:libcontainers:stable.list /etc/apt/sources.list.d/
+        echo "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$CRIOVERSION/$OS/ /" > devel:kubic:libcontainers:stable:cri-o:$CRIOVERSION.list
+        sudo mv devel:kubic:libcontainers:stable:cri-o:$CRIOVERSION.list /etc/apt/sources.list.d/
+
+        curl -L https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:$CRIOVERSION/$OS/Release.key | sudo apt-key add -
+        curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/Release.key | sudo apt-key add -
+
+        sudo apt-get update -y
+        # Vagrant Ubuntu VMs don't provide containernetworking-plugins by default
+        sudo apt-get install -y cri-o cri-o-runc cri-tools containernetworking-plugins
       ;;
     esac
 }
@@ -182,14 +204,16 @@ User=root
 WantedBy=multi-user.target
 EOF
 
-    sudo mkdir -p /var/run/flannel
-    sudo mkdir -p /var/run/kubelet
-    sudo mkdir -p /var/lib/kubelet/pods
-    sudo mkdir -p /var/run/secrets/kubernetes.io/serviceaccount
-    sudo mkdir -p /var/hpvolumes
-    sudo semodule -i /tmp/microshift.pp
-    sudo restorecon -v /usr/local/bin/microshift
-    sudo restorecon -v /var/hpvolumes
+    if [ "$DISTRO" != "ubuntu" ]; then
+        sudo mkdir -p /var/run/flannel
+        sudo mkdir -p /var/run/kubelet
+        sudo mkdir -p /var/lib/kubelet/pods
+        sudo mkdir -p /var/run/secrets/kubernetes.io/serviceaccount
+        sudo mkdir -p /var/hpvolumes
+        sudo semodule -i /tmp/microshift.pp
+        sudo restorecon -v /usr/local/bin/microshift
+        sudo restorecon -v /var/hpvolumes
+    fi
     sudo systemctl enable microshift.service --now
 
 }
@@ -230,7 +254,9 @@ fi
 validation_check
 install_dependencies
 establish_firewall
-build_selinux_policy
+if [ "$DISTRO" != "ubuntu" ]; then
+    build_selinux_policy
+fi
 install_crio
 crio_conf
 verify_crio


### PR DESCRIPTION
I tested this with Vagrant `ubuntu/focal64` box and it works. Note due to #263, however, at this moment you can only do this:
```
CONFIG_ENV_ONLY=true ./install.sh
```
and you need to install `microshift` yourself with a [local build for Ubuntu](https://github.com/tadayosi/microshift/releases/download/test-ubuntu/microshift-ubuntu.tar.xz).

Other notes on the fix:
- `set -e -o pipefail` is bash specific so it doesn't make sense to use `/bin/sh`. Also `/bin/sh` resolves to `dash` on Ubuntu by default
- SELinux is already disabled by default for Ubuntu

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/redhat-et/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
No issues related to the pull req.
