### PR TITLE
Create RPM SELinux sub-module

### DIFF
--- a/selinux/Makefile
+++ b/selinux/Makefile
@@ -1,0 +1,26 @@
+TARGET?=microshift
+MODULES?=${TARGET:=.pp.bz2}
+SHAREDIR?=/usr/share
+
+all: ${TARGET:=.pp.bz2}
+
+%.pp.bz2: %.pp
+	@echo Compressing $^ -\> $@
+	bzip2 -9 $^
+
+%.pp: %.te
+	make -f ${SHAREDIR}/selinux/devel/Makefile $@
+
+clean:
+	rm -f *~  *.tc *.pp *.pp.bz2
+	rm -rf tmp *.tar.gz
+
+man: install-policy
+	sepolicy manpage --path . --domain ${TARGET}_t
+
+install-policy: all
+	semodule -i ${TARGET}.pp.bz2
+
+install: man
+	install -D -m 644 ${TARGET}.pp.bz2 ${DESTDIR}${SHAREDIR}/selinux/packages/${TARGET}.pp.bz2
+	install -D -m 644 ${TARGET}_selinux.8 ${DESTDIR}${SHAREDIR}/man/man8/

--- a/selinux/microshift.fc
+++ b/selinux/microshift.fc
@@ -2,4 +2,5 @@
 /var/run/secrets/kubernetes.io/serviceaccount(/.*)?				gen_context(system_u:object_r:container_runtime_tmpfs_t,s0)
 /var/lib/microshift/certs/ca-bundle(/.*)?                                       gen_context(system_u:object_r:container_file_t,s0)
 /usr/local/bin/microshift                                                  --	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/bin/microshift                                                        --	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /var/hpvolumes(/.*)?            						gen_context(system_u:object_r:container_file_t,s0)


### PR DESCRIPTION
Adds a Makefile for the selinux directory to help with local development
and adds an selinux microshift sub-package which contains the selinux
policies.

Related-Issue: #277

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
