### PR TITLE
add fully aio systemd unit file and script

### DIFF
--- a/hack/all-in-one/README.md
+++ b/hack/all-in-one/README.md
@@ -1,5 +1,35 @@
 # Containerized Microshift 
 
+## Run microshift all-in-one as a systemd service
+
+Copy microshift-aio unit file to /etc/systemd and the aio-run to /usr/bin
+
+```bash
+cp microshift-aio.service /etc/systemd/system/microshift-aio.service
+cp microshift-aio-run /usr/bin/
+```
+Now enable and start the service. The KUBECONFIG location will be written to /etc/microshift-aio/microshift-aio.conf
+If the `microshift-vol` podman volume does not exist, the systemd service will create one.
+
+```bash
+systemctl enable microshift-aio --now
+source /etc/microshift-aio/microshift-aio.conf
+```
+
+Verify that microshift is running.
+```
+kubectl get pods -A
+```
+
+Stop microshift-aio service
+
+```bash
+systemctl stop microshift-aio
+```
+
+**NOTE** Stopping microshift-aio service _does not_ remove the podman volume `microshift-vol`.
+A restart will use the same volume.
+
 ## Build Container Image
 First copy microshift binary to this directory, then build the container image:
 ```bash

--- a/hack/all-in-one/microshift-aio-run
+++ b/hack/all-in-one/microshift-aio-run
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+setsebool -P container_manage_cgroup true
+
+if ! /usr/bin/podman volume exists microshift-vol
+then
+  /usr/bin/podman volume create microshift-vol
+fi
+
+[[ -d /etc/microshift-aio ]] || mkdir /etc/microshift-aio
+
+/usr/bin/podman run -d --rm \
+  --name microshift --privileged \
+  -v /lib/modules:/lib/modules \
+  -v microshift-vol:/var/lib \
+  --hostname microshift \
+  --label "io.containers.autoupdate=registry" \
+  -p 6443:6443 quay.io/microshift/microshift:4.7.0-0.microshift-2021-08-31-224727-aio
+
+cat <<EOF > /etc/microshift-aio/microshift-aio.conf
+export KUBECONFIG=$(/usr/bin/podman volume inspect microshift-vol --format "{{.Mountpoint}}")/microshift/resources/kubeadmin/kubeconfig
+EOF

--- a/hack/all-in-one/microshift-aio.service
+++ b/hack/all-in-one/microshift-aio.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=microshift all-in-one
+Wants=network-online.target
+After=network-online.target
+RequiresMountsFor=/run/containers/storage
+
+[Service]
+Restart=on-failure
+TimeoutStopSec=70
+ExecStart=/bin/bash /usr/bin/microshift-aio-run
+ExecStop=/usr/bin/podman stop -t 20 microshift 
+Type=forking
+
+[Install]
+WantedBy=multi-user.target default.target


### PR DESCRIPTION
Signed-off-by: Sally O'Malley <somalley@redhat.com>
Signed-off-by: Parul Singh <parsingh@redhat.com> 

**Which issue(s) this PR addresses**:
This PR partially resolves https://github.com/redhat-et/microshift/issues/276

This PR:
Adds a systemd unit file to run microshift all-in-one with podman
The service:
-  creates `microshift-vol` podman volume if it does not exist
-  starts microshift via podman run command
-  writes location of KUBECONFIG to /etc/microshift-aio/microshift-aio.conf for easy `source /etc/microshift-aio/microshift-aio.conf` upon service startup
-  included the auto-update podman annotation, but this needs testing to be sure it works correctly (ie, not sure which tags, if it changes the tags)

* With `systemctl stop microshift-aoi`
    * microshift pod is stopped/deleted
    * `microshift-vol` is _not_ deleted
