### PR TITLE
add sudo to podman to avoid rootless

### DIFF
--- a/hack/all-in-one/README.md
+++ b/hack/all-in-one/README.md
@@ -9,7 +9,7 @@ cp microshift-aio.service /etc/systemd/system/microshift-aio.service
 cp microshift-aio-run /usr/bin/
 ```
 Now enable and start the service. The KUBECONFIG location will be written to /etc/microshift-aio/microshift-aio.conf.    
-If the `microshift-vol` podman volume does not exist, the systemd service will create one.
+If the `microshift-data` podman volume does not exist, the systemd service will create one.
 
 ```bash
 systemctl enable microshift-aio --now
@@ -27,13 +27,13 @@ Stop microshift-aio service
 systemctl stop microshift-aio
 ```
 
-**NOTE** Stopping microshift-aio service _does not_ remove the podman volume `microshift-vol`.
+**NOTE** Stopping microshift-aio service _does not_ remove the podman volume `microshift-data`.
 A restart will use the same volume.
 
 ## Build Container Image
 First copy microshift binary to this directory, then build the container image:
 ```bash
-podman build -t ushift .
+sudo podman build -t microshift-aio .
 ```
 
 ## Run the Image
@@ -44,12 +44,12 @@ setsebool -P container_manage_cgroup true
 ```
 Next, create a container volume:
 ```bash
-podman volume create ushift-vol
+sudo podman volume create microshift-data
 ```
 The following example binds localhost the container volume to `/var/lib`
 
 ```bash
- podman run -d --rm --name ushift --privileged -v /lib/modules:/lib/modules -v ushift-vol:/var/lib --hostname ushift -p 6443:6443 ushift  
+sudo podman run -d --rm --name microshift-aio --privileged -v /lib/modules:/lib/modules -v microshift-data:/var/lib  -p 6443:6443 microshift-aio  
 ```
 
 Then you can access the cluster either on the host or inside the container
@@ -57,7 +57,7 @@ Then you can access the cluster either on the host or inside the container
 ### Access the cluster inside the container
 Execute the following command to get into the container:
 ```bash
-podman exec -ti ushift bash
+sudo podman exec -ti microshift-aio bash
 ```
 Inside the container, run the following to see the pods:
 ```bash

--- a/hack/all-in-one/microshift-aio-run
+++ b/hack/all-in-one/microshift-aio-run
@@ -4,18 +4,17 @@ set -euxo pipefail
 
 setsebool -P container_manage_cgroup true
 
-if ! /usr/bin/podman volume exists microshift-vol
+if ! /usr/bin/podman volume exists microshift-data
 then
-  /usr/bin/podman volume create microshift-vol
+  /usr/bin/podman volume create microshift-data
 fi
 
 [[ -d /etc/microshift-aio ]] || mkdir /etc/microshift-aio
 
 /usr/bin/podman run -d --rm \
-  --name microshift --privileged \
+  --name microshift-aio --privileged \
   -v /lib/modules:/lib/modules \
-  -v microshift-vol:/var/lib \
-  --hostname microshift \
+  -v microshift-data:/var/lib \
   --label "io.containers.autoupdate=registry" \
   -p 6443:6443 quay.io/microshift/microshift:4.7.0-0.microshift-2021-08-31-224727-aio
 


### PR DESCRIPTION
Signed-off-by: Parul <parsingh@redhat.com>

To be able to run microshift via podman we need to run podman as sudo otherwise the cluster never gets up and running as nodes are stuck in NotReady state. 
