### PR TITLE
typo in microshift-aio container name on ExecStop

### DIFF
--- a/hack/all-in-one/README.md
+++ b/hack/all-in-one/README.md
@@ -2,11 +2,11 @@
 
 ## Run microshift all-in-one as a systemd service
 
-Copy microshift-aio unit file to /etc/systemd and the aio-run to /usr/bin
+Copy microshift-aio unit file to /etc/systemd and the aio run script to /usr/bin
 
 ```bash
 cp microshift-aio.service /etc/systemd/system/microshift-aio.service
-cp microshift-aio-run /usr/bin/
+cp microshift-aio /usr/bin/
 ```
 Now enable and start the service. The KUBECONFIG location will be written to /etc/microshift-aio/microshift-aio.conf.    
 If the `microshift-data` podman volume does not exist, the systemd service will create one.

--- a/hack/all-in-one/microshift-aio
+++ b/hack/all-in-one/microshift-aio
@@ -2,14 +2,13 @@
 
 set -euxo pipefail
 
+microshift_start() {
 setsebool -P container_manage_cgroup true
 
 if ! /usr/bin/podman volume exists microshift-data
 then
   /usr/bin/podman volume create microshift-data
 fi
-
-[[ -d /etc/microshift-aio ]] || mkdir /etc/microshift-aio
 
 /usr/bin/podman run -d --rm \
   --name microshift-aio --privileged \
@@ -18,6 +17,24 @@ fi
   --label "io.containers.autoupdate=registry" \
   -p 6443:6443 quay.io/microshift/microshift:4.7.0-0.microshift-2021-08-31-224727-aio
 
+[[ -d /etc/microshift-aio ]] || mkdir /etc/microshift-aio
 cat <<EOF > /etc/microshift-aio/microshift-aio.conf
-export KUBECONFIG=$(/usr/bin/podman volume inspect microshift-vol --format "{{.Mountpoint}}")/microshift/resources/kubeadmin/kubeconfig
+export KUBECONFIG=$(/usr/bin/podman volume inspect microshift-data --format "{{.Mountpoint}}")/microshift/resources/kubeadmin/kubeconfig
 EOF
+}
+
+microshift_stop() {
+    /usr/bin/podman stop -t 20 microshift-aio
+}
+
+arg="$1"
+if [[ $arg == "start" ]]
+then
+  microshift_start
+elif [[ $arg == "stop" ]]
+then
+  microshift_stop
+else
+  echo "$arg: unknown argument-only allowed 'start' and 'stop'"
+  exit 1
+fi

--- a/hack/all-in-one/microshift-aio.service
+++ b/hack/all-in-one/microshift-aio.service
@@ -8,7 +8,7 @@ RequiresMountsFor=/run/containers/storage
 Restart=on-failure
 TimeoutStopSec=70
 ExecStart=/bin/bash /usr/bin/microshift-aio-run
-ExecStop=/usr/bin/podman stop -t 20 microshift 
+ExecStop=/usr/bin/podman stop -t 20 microshift-aio 
 Type=forking
 
 [Install]

--- a/hack/all-in-one/microshift-aio.service
+++ b/hack/all-in-one/microshift-aio.service
@@ -7,8 +7,8 @@ RequiresMountsFor=/run/containers/storage
 [Service]
 Restart=on-failure
 TimeoutStopSec=70
-ExecStart=/bin/bash /usr/bin/microshift-aio-run
-ExecStop=/usr/bin/podman stop -t 20 microshift-aio 
+ExecStart=/bin/bash /usr/bin/microshift-aio start
+ExecStop=/bin/bash /usr/bin/microshift-aio stop
 Type=forking
 
 [Install]


### PR DESCRIPTION
Signed-off-by: Sally O'Malley <somalley@redhat.com>

* typo in container name for microshift-aio.service ExecStop
* create "start" "stop" args in the microshift-aio-run script, rename script to microshift-aio
* typo in kubeconfig path record, updated vol to microshift-data there