### PR TITLE
Embed git tags, commit ID and tree status in srpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ RELEASE_PRE := ${RELEASE_BASE}-0.microshift
 # because since it doesn't work with our version scheme.
 SOURCE_GIT_TAG :=$(shell git describe --tags --abbrev=7 --match '$(RELEASE_PRE)*' || echo '4.8.0-0.microshift-unknown')
 
+EMBEDDED_GIT_TAG ?= ${SOURCE_GIT_TAG}
+EMBEDDED_GIT_COMMIT ?= ${SOURCE_GIT_COMMIT}
+EMBEDDED_GIT_TREE_STATE ?= ${SOURCE_GIT_TREE_STATE}
+
+
 SRC_ROOT :=$(shell pwd)
 
 IMAGE_REPO :=quay.io/microshift/microshift
@@ -48,9 +53,9 @@ GO_LD_FLAGS :=-ldflags "-X k8s.io/component-base/version.gitMajor=1 \
                    -X k8s.io/client-go/pkg/version.gitCommit=b09a9ce3 \
                    -X k8s.io/client-go/pkg/version.gitTreeState=clean \
                    -X k8s.io/client-go/pkg/version.buildDate=$(BIN_TIMESTAMP) \
-                   -X github.com/openshift/microshift/pkg/version.versionFromGit=$(SOURCE_GIT_TAG) \
-                   -X github.com/openshift/microshift/pkg/version.commitFromGit=$(SOURCE_GIT_COMMIT) \
-                   -X github.com/openshift/microshift/pkg/version.gitTreeState=$(SOURCE_GIT_TREE_STATE) \
+                   -X github.com/openshift/microshift/pkg/version.versionFromGit=$(EMBEDDED_GIT_TAG) \
+                   -X github.com/openshift/microshift/pkg/version.commitFromGit=$(EMBEDDED_GIT_COMMIT) \
+                   -X github.com/openshift/microshift/pkg/version.gitTreeState=$(EMBEDDED_GIT_TREE_STATE) \
                    -X github.com/openshift/microshift/pkg/version.buildDate=$(BIN_TIMESTAMP) \
                    -s -w"
 
@@ -135,12 +140,17 @@ cross-build: cross-build-linux-amd64 cross-build-linux-arm64
 .PHONY: cross-build
 
 rpm:
-	BUILD=rpm RELEASE_BASE=${RELEASE_BASE} RELEASE_PRE=${RELEASE_PRE} ./packaging/rpm/make-rpm.sh local
-
+	BUILD=rpm \
+	SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
+	SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} RELEASE_BASE=${RELEASE_BASE}  \
+	RELEASE_PRE=${RELEASE_PRE} ./packaging/rpm/make-rpm.sh local
 .PHONY: rpm
 
 srpm:
-	BUILD=srpm RELEASE_BASE=${RELEASE_BASE} RELEASE_PRE=${RELEASE_PRE} ./packaging/rpm/make-rpm.sh local
+	BUILD=srpm \
+	SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
+	SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} RELEASE_BASE=${RELEASE_BASE}  \
+	RELEASE_PRE=${RELEASE_PRE} ./packaging/rpm/make-rpm.sh local
 .PHONY: srpm
 
 ###############################

--- a/packaging/rpm/make-rpm.sh
+++ b/packaging/rpm/make-rpm.sh
@@ -19,6 +19,9 @@ GIT_SHORTHASH="${GIT_SHA:0:7}"
 TARBALL_FILE="microshift-${GIT_SHORTHASH}.tar.gz"
 RPMBUILD_DIR="${SCRIPT_DIR}/_rpmbuild/"
 
+SOURCE_GIT_TAG="$(git describe --tags | sed s/nightly-/nightly-$(git show -s --format=%ct)_/g )"
+
+
 create_local_tarball() {
   tar -czf "${RPMBUILD_DIR}/SOURCES/${TARBALL_FILE}" \
             --exclude='.git' --exclude='.idea' --exclude='.vagrant' \
@@ -52,6 +55,9 @@ build_commit() {
 %global release ${RPM_REL}
 %global version ${RELEASE_BASE}
 %global git_commit ${1}
+%global embedded_git_commit ${SOURCE_GIT_COMMIT}
+%global embedded_git_tag ${SOURCE_GIT_TAG}
+%global embedded_git_tree_state ${SOURCE_GIT_TREE_STATE}
 EOF
   cat "${SCRIPT_DIR}/microshift.spec" >> "${RPMBUILD_DIR}SPECS/microshift.spec"
 
@@ -63,6 +69,9 @@ build_tag_commit() {
 %global release ${RPM_REL}
 %global version ${RELEASE_BASE}
 %global github_tag ${1}
+%global embedded_git_commit ${SOURCE_GIT_COMMIT}
+%global embedded_git_tag ${SOURCE_GIT_TAG}
+%global embedded_git_tree_state ${SOURCE_GIT_TREE_STATE}
 EOF
   cat "${SCRIPT_DIR}/microshift.spec" >> "${RPMBUILD_DIR}SPECS/microshift.spec"
 

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -156,7 +156,13 @@ GOARCH=s390x
 GOARCH=amd64
 %endif
 
+# if we have git commit/tag/state to be embedded in the binary pass it down to the makefile
+%if 0%{?embedded_git_commit:1}
+make _build_local GOOS=${GOOS} GOARCH=${GOARCH} EMBEDDED_GIT_COMMIT=%{embedded_git_commit} EMBEDDED_GIT_TAG=%{embedded_git_tag} EMBEDDED_GIT_TREE_STATE=%{embedded_git_tree_state}
+%else
 make _build_local GOOS=${GOOS} GOARCH=${GOARCH}
+%endif
+
 cp ./_output/bin/${GOOS}_${GOARCH}/microshift ./_output/microshift
 
 # SELinux modules build


### PR DESCRIPTION
Embedding those details, and then injecting then back during
srpm building (instead of looking for the git details which
doesn't exist anymore for an srpm build -it's a tarball-)
allows for microshift being properly compiled with those
details in the binary.

Closes-Issue: #476

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
