### PR TITLE
Remove the --broke(n) git describe flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ RELEASE_PRE := ${RELEASE_BASE}-0.microshift
 
 # Overload SOURCE_GIT_TAG value set in vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
 # because since it doesn't work with our version scheme.
-SOURCE_GIT_TAG :=$(shell git describe --tags --abbrev=7 --broke --match '$(RELEASE_PRE)*' || echo '4.7.0-0.microshift-unknown')
+SOURCE_GIT_TAG :=$(shell git describe --tags --abbrev=7 --match '$(RELEASE_PRE)*' || echo '4.7.0-0.microshift-unknown')
 
 SRC_ROOT :=$(shell pwd)
 


### PR DESCRIPTION
It's incompatible with the git version installed in the openshift
release CI [1]. And it's only meant to detect broken git repositories
instead of failing the git command. But we handle that already with the
`|| echo '4.7.0-0.microshift-unknown` part.

[1] https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/22178/rehearse-22178-pull-ci-redhat-et-microshift-main-test-rpm/1441081828843720704

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
