### PR TITLE
Continue support for RHEL7

### DIFF
--- a/hack/all-in-one/Dockerfile
+++ b/hack/all-in-one/Dockerfile
@@ -1,7 +1,8 @@
 ARG IMAGE_NAME=registry.access.redhat.com/ubi8/ubi-init:8.4
-ARG IPTABLES=nft
 
 FROM ${IMAGE_NAME}
+
+ARG HOST=rhel8
 
 RUN export VERSION=$(curl -s https://api.github.com/repos/redhat-et/microshift/releases | grep tag_name | head -n 1 | cut -d '"' -f 4) && \
     export ARCH=$(uname -m |sed -e "s/x86_64/amd64/" |sed -e "s/aarch64/arm64/") && \
@@ -19,7 +20,6 @@ RUN export VERSION=1.20 && \
 
 RUN dnf install -y cri-o \
         cri-tools \
-        iptables \ 
         iproute \
         procps-ng && \
     dnf clean all
@@ -35,12 +35,14 @@ RUN export ARCH=$(uname -m |sed -e "s/x86_64/amd64/" |sed -e "s/aarch64/arm64/")
 RUN curl -s -L https://nvidia.github.io/nvidia-docker/rhel8.3/nvidia-docker.repo | tee /etc/yum.repos.d/nvidia-docker.repo && \
     dnf install nvidia-container-toolkit -y
 
-RUN if [ "$IPTABLES" != "nft" ]; then yum remove iptables -y && \
-    yum install -y https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/28/Everything/x86_64/os/Packages/i/iptables-libs-1.6.2-2.fc28.x86_64.rpm && \
-    yum install -y https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/28/Everything/x86_64/os/Packages/i/iptables-1.6.2-2.fc28.x86_64.rpm ; fi
-
-
-
+RUN if [ "$HOST" == "rhel8" ]; then  \
+        dnf install -y iptables; \
+    else \
+      dnf install -y libnetfilter_conntrack libnfnetlink && \
+      rpm -v -i --force https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/28/Everything/x86_64/os/Packages/i/iptables-libs-1.6.2-2.fc28.x86_64.rpm \
+                   https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/28/Everything/x86_64/os/Packages/i/iptables-1.6.2-2.fc28.x86_64.rpm && \
+      sed -e '/mountopt/s/,\?metacopy=on,\?//' -i /etc/containers/storage.conf; \
+    fi
 ADD nvidia-config.toml /etc/nvidia-container-runtime/config.toml
 
 CMD [ "/sbin/init" ]

--- a/hack/all-in-one/build-images.sh
+++ b/hack/all-in-one/build-images.sh
@@ -6,9 +6,9 @@ for img in "registry.access.redhat.com/ubi8/ubi-init:8.4" "docker.io/nvidia/cuda
    tag=$(echo ${img} |awk -F"/" '{print $NF}'| sed -e 's/:/-/g')
    echo ${tag}
 
-   for iptables in "nft" "legacy-iptables"; do
-        iptables_tag=""
-        [ "${iptables}" == "legacy-iptables" ] && iptables_tag = "-legacy-iptables"
-        podman build --build-arg IMAGE_NAME=${img} --build-arg IPTABLES=${iptables} -t ${TAG}-${tag}${iptables_tag} .
+   for host in "rhel7" "rhel8"; do
+        host_tag=""
+        [ "${host}" == "rhel7" ] && host_tag="-rhel7"
+        podman build --build-arg IMAGE_NAME=${img} --build-arg HOST=${host} -t ${TAG}-${tag}${host_tag} .
    done
 done


### PR DESCRIPTION
Fix the build-images and some issues with the fc28 iptables
rpm installation.

My version of the #304 in #309 was missing the containers storage.conf
fix for rhel7.

Co-Authored-By: Huamin Chen <hchen@redhat.com>
Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
