### PR TITLE
Improve and pack the cleanup script in the rpms

### DIFF
--- a/hack/cleanup.sh
+++ b/hack/cleanup.sh
@@ -1,9 +1,26 @@
 #!/bin/sh
-
 set -eu
+
+echo "DATA LOSS WARNING: Do you wish to stop and cleanup ALL MicroShift data AND cri-o container workloads?"
+select yn in "Yes" "No"; do
+    case "${yn}" in
+        Yes ) break ;;
+        * ) echo "aborting cleanup; " ; exit;;
+    esac
+done
 
 # crictl redirect STDOUT.  When no objects (pod, image, container) are present, crictl dump the help menu instead.  This may be confusing to users.
 sudo bash -c '
+    echo "Stopping microshift"
+    set +e
+    systemctl stop --now microshift 2>/dev/null
+    systemctl disable microshift 2>/dev/null
+    systemctl stop --now microshift-containerized 2>/dev/null
+    systemctl disable microshift-containerized 2>/dev/null
+    podman stop microshift 2>/dev/null
+    podman stop microshift-aio 2>/dev/null
+    set -e
+
     echo "Removing crio pods"
     until crictl rmp --all --force 1>/dev/null; do sleep 1; done
 
@@ -13,9 +30,11 @@ sudo bash -c '
     echo "Removing crio images"
     crictl rmi --all --prune 1>/dev/null
 
-    echo "Killing conmoni, pause processes"
+    echo "Killing conmon, pause processes"
     pkill -9 conmon
     pkill -9 pause
+
+
 
     echo "Removing /var/lib/microshift"
     rm -rf /var/lib/microshift

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -132,6 +132,8 @@ make
 
 install -d %{buildroot}%{_bindir}
 install -p -m755 ./_output/microshift %{buildroot}%{_bindir}/microshift
+install -p -m755 hack/cleanup.sh %{buildroot}%{_bindir}/cleanup-all-microshift-data
+
 restorecon -v %{buildroot}%{_bindir}/microshift
 
 install -d -m755 %{buildroot}/%{_unitdir}
@@ -174,6 +176,7 @@ fi
 
 %license LICENSE
 %{_bindir}/microshift
+%{_bindir}/cleanup-all-microshift-data
 %{_unitdir}/microshift.service
 
 %files selinux
@@ -182,6 +185,9 @@ fi
 %ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/microshift
 
 %changelog
+* Thu Nov 4 2021 Miguel Angel Ajo <majopela@redhat.com> . 4.8.0-nightly-13-g886705e5
+- Include the cleanup-all-microshift-data script for convenience
+
 * Thu Sep 23 2021 Miguel Angel Ajo <majopela@redhat.com> . 4.7.0-021_08_31_224727_40_g5c23735f
 - Support commit based builds
 - workaround rpmbuild with no build in place support


### PR DESCRIPTION
This will allow running `cleanup-all-microshift-data` which will
ask for confirmation. This is something which should be useful
during development phase and which could potentially be removed
for a final product.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
