### PR TITLE
mDNS responder for microshift

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -436,6 +436,7 @@ require (
 	github.com/heketi/tests v0.0.0-00010101000000-000000000000 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // microshift
 	github.com/lpabon/godbc v0.0.0-00010101000000-000000000000 // indirect
+	github.com/miekg/dns v1.1.35
 	github.com/mitchellh/go-homedir v1.1.0 // microshift
 	github.com/moby/sys/mount v0.2.0 // indirect
 	github.com/mohae/deepcopy v0.0.0-00010101000000-000000000000 // indirect
@@ -460,6 +461,7 @@ require (
 	k8s.io/client-go v0.21.1
 	k8s.io/component-base v0.21.1
 	k8s.io/controller-manager v0.21.0
+	k8s.io/klog/v2 v2.8.0
 	k8s.io/kube-aggregator v0.21.0
 	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7
 	k8s.io/kubectl v0.21.0

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -82,7 +82,9 @@ func initCerts(cfg *config.MicroshiftConfig) error {
 	}
 	if err := util.GenCerts("kube-apiserver", cfg.DataDir+"/certs/kube-apiserver/secrets/service-network-serving-certkey",
 		"tls.crt", "tls.key",
-		[]string{"kube-apiserver", cfg.NodeIP, "127.0.0.1", "kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost", apiServerServiceIP.String()}); err != nil {
+		[]string{"kube-apiserver", cfg.NodeIP, cfg.NodeName, "127.0.0.1", "kubernetes.default.svc", "kubernetes.default", "kubernetes",
+			"localhost",
+			apiServerServiceIP.String()}); err != nil {
 		return err
 	}
 	if err := util.GenKeys(cfg.DataDir+"/resources/kube-apiserver/secrets/service-account-key",
@@ -113,12 +115,14 @@ func initCerts(cfg *config.MicroshiftConfig) error {
 	// ocp
 	if err := util.GenCerts("openshift-apiserver", cfg.DataDir+"/resources/openshift-apiserver/secrets",
 		"tls.crt", "tls.key",
-		[]string{"openshift-apiserver", cfg.NodeIP, "openshift-apiserver.default.svc", "openshift-apiserver.default", "127.0.0.1", "kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost"}); err != nil {
+		[]string{"openshift-apiserver", cfg.NodeIP, cfg.NodeName, "openshift-apiserver.default.svc", "openshift-apiserver.default",
+			"127.0.0.1", "kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost"}); err != nil {
 		return err
 	}
 	if err := util.GenCerts("openshift-controller-manager", cfg.DataDir+"/resources/openshift-controller-manager/secrets",
 		"tls.crt", "tls.key",
-		[]string{"openshift-controller-manager", cfg.NodeIP, "127.0.0.1", "kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost"}); err != nil {
+		[]string{"openshift-controller-manager", cfg.NodeName, cfg.NodeIP, "127.0.0.1", "kubernetes.default.svc", "kubernetes.default",
+			"kubernetes", "localhost"}); err != nil {
 		return err
 	}
 	if err := util.GenCerts("service-ca", cfg.DataDir+"/resources/service-ca/secrets/service-ca",
@@ -128,7 +132,8 @@ func initCerts(cfg *config.MicroshiftConfig) error {
 	}
 	if err := util.GenCerts("openshift-oauth-apiserver", cfg.DataDir+"/resources/openshift-oauth-apiserver/secrets",
 		"tls.crt", "tls.key",
-		[]string{"openshift-oauth-apiserver", cfg.NodeIP, "127.0.0.1", "openshift-oauth-apiserver.default.svc", "openshift-oauth-apiserver.svc", "kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost"}); err != nil {
+		[]string{"openshift-oauth-apiserver", cfg.NodeIP, cfg.NodeName, "127.0.0.1", "openshift-oauth-apiserver.default.svc",
+			"openshift-oauth-apiserver.svc", "kubernetes.default.svc", "kubernetes.default", "kubernetes", "localhost"}); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/microshift/pkg/config"
 	"github.com/openshift/microshift/pkg/controllers"
 	"github.com/openshift/microshift/pkg/kustomize"
+	"github.com/openshift/microshift/pkg/mdns"
 	"github.com/openshift/microshift/pkg/node"
 	"github.com/openshift/microshift/pkg/servicemanager"
 	"github.com/openshift/microshift/pkg/util"
@@ -77,6 +78,7 @@ func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 		util.Must(m.AddService(controllers.NewOpenShiftOAuth(cfg)))
 
 		util.Must(m.AddService(controllers.NewOpenShiftAPIComponents(cfg)))
+		util.Must(m.AddService(mdns.NewMicroShiftmDNSController(cfg)))
 		util.Must(m.AddService(controllers.NewInfrastructureServices(cfg)))
 		util.Must(m.AddService(kustomize.NewKustomizer(cfg)))
 	}

--- a/pkg/mdns/controller.go
+++ b/pkg/mdns/controller.go
@@ -1,0 +1,108 @@
+package mdns
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/openshift/microshift/pkg/config"
+	"github.com/openshift/microshift/pkg/mdns/server"
+	"k8s.io/klog/v2"
+)
+
+type MicroShiftmDNSController struct {
+	sync.Mutex
+	NodeName   string
+	NodeIP     string
+	KubeConfig string
+	myIPs      []string
+	resolver   *server.Resolver
+	hostCount  map[string]int
+	stopCh     chan struct{}
+}
+
+func NewMicroShiftmDNSController(cfg *config.MicroshiftConfig) *MicroShiftmDNSController {
+	return &MicroShiftmDNSController{
+		NodeIP:     cfg.NodeIP,
+		NodeName:   cfg.NodeName,
+		KubeConfig: filepath.Join(cfg.DataDir, "resources", "kubeadmin", "kubeconfig"),
+		hostCount:  make(map[string]int),
+	}
+}
+
+func (s *MicroShiftmDNSController) Name() string { return "microshift-mdns-controller" }
+func (s *MicroShiftmDNSController) Dependencies() []string {
+	return []string{"openshift-api-components-manager"}
+}
+
+func (c *MicroShiftmDNSController) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {
+	defer close(stopped)
+
+	c.stopCh = make(chan struct{})
+	defer close(c.stopCh)
+
+	c.resolver = server.NewResolver()
+
+	ifs, _ := net.Interfaces()
+
+	for n := range ifs {
+		name := ifs[n].Name
+		if strings.HasPrefix(name, "flannel") ||
+			strings.HasPrefix(name, "veth") ||
+			strings.HasPrefix(name, "cni") {
+			continue
+		}
+		klog.InfoS("starting mDNS server", "interface", name, "NodeIP", c.NodeIP, "Node", c.NodeName)
+		server.New(&ifs[n], c.resolver, c.stopCh)
+	}
+
+	if strings.HasSuffix(c.NodeName, server.DefaultmDNSTLD) {
+		ips := []string{c.NodeIP}
+
+		// Discover additional IPs for the interface (IPv6 LLA ...)
+		for n := range ifs {
+			addrs, _ := ifs[n].Addrs()
+			if ipInAddrs(c.NodeIP, addrs) {
+				ips = addrsToStrings(addrs)
+			}
+		}
+
+		klog.InfoS("Host FQDN will be announced via mDNS", "fqdn", c.NodeName, "ips", ips)
+		c.resolver.AddDomain(c.NodeName, ips)
+		c.myIPs = ips
+	}
+
+	close(ready)
+
+	go c.startRouteInformer(c.stopCh)
+
+	select {
+	case <-ctx.Done():
+
+		return ctx.Err()
+	}
+
+	return nil
+}
+
+func ipInAddrs(ip string, addrs []net.Addr) bool {
+	for _, a := range addrs {
+		ipAddr, _, _ := net.ParseCIDR(a.String())
+		if ipAddr.String() == ip {
+			return true
+		}
+	}
+	return false
+}
+
+func addrsToStrings(addrs []net.Addr) []string {
+	var ipAddrs []string
+
+	for _, a := range addrs {
+		ipAddr, _, _ := net.ParseCIDR(a.String())
+		ipAddrs = append(ipAddrs, ipAddr.String())
+	}
+	return ipAddrs
+}

--- a/pkg/mdns/routes.go
+++ b/pkg/mdns/routes.go
@@ -1,0 +1,161 @@
+package mdns
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/openshift/microshift/pkg/mdns/server"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+)
+
+const defaultResyncTime = time.Hour * 1
+
+func (c *MicroShiftmDNSController) restConfig() (*rest.Config, error) {
+	return clientcmd.BuildConfigFromFlags("", c.KubeConfig)
+}
+
+func (c *MicroShiftmDNSController) startRouteInformer(stopCh chan struct{}) error {
+	klog.InfoS("Starting MicroShift mDNS route watcher")
+	cfg, err := c.restConfig()
+	if err != nil {
+		return errors.Wrap(err, "error creating rest config for route informer")
+	}
+
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return errors.Wrap(err, "error creating dynamic informer")
+	}
+
+	return c.run(stopCh, dc)
+}
+
+func (c *MicroShiftmDNSController) run(stopCh chan struct{}, dc dynamic.Interface) error {
+	informerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dc, defaultResyncTime, v1.NamespaceAll, nil)
+	routersGVR, _ := schema.ParseResourceArg("routes.v1.route.openshift.io")
+
+	informer := informerFactory.ForResource(*routersGVR).Informer()
+	c.waitForRouterAPI(dc, routersGVR)
+
+	handlers := cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addedRoute,
+		UpdateFunc: c.updatedRoute,
+		DeleteFunc: c.deletedRoute,
+	}
+
+	informer.AddEventHandler(handlers)
+	informer.Run(stopCh)
+
+	return nil
+}
+
+// TODO: The need for this indicates that the openshift-api-components-manager is declaring itself ready before
+//       it really is. If we don't wait for the route API the informer will start throwing ugly errors.
+func (c *MicroShiftmDNSController) waitForRouterAPI(dc dynamic.Interface, routersGVR *schema.GroupVersionResource) {
+	backoff := wait.Backoff{
+		Cap:      3 * time.Minute,
+		Duration: 10 * time.Second,
+		Factor:   1.5,
+		Steps:    24,
+	}
+
+	klog.InfoS("mDNS: waiting for route API to be ready")
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		_, err := dc.Resource(*routersGVR).List(context.TODO(), metav1.ListOptions{})
+		if err == nil {
+			return true, nil
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		// This is a soft error, the watcher down the line will keep waiting, but will emit
+		// less nice errors
+		klog.ErrorS(err, "waiting for the route.openshift.io/v1 API to come up")
+	} else {
+		klog.InfoS("mDNS: route API ready, watching routers")
+	}
+}
+
+func (c *MicroShiftmDNSController) addedRoute(obj interface{}) {
+	u := obj.(*unstructured.Unstructured)
+
+	host, found, err := unstructured.NestedString(u.UnstructuredContent(), "spec", "host")
+	if !found || err != nil {
+		klog.ErrorS(err, "mDNS spec.host not found")
+		return
+	}
+
+	c.exposeHost(host)
+}
+
+func (c *MicroShiftmDNSController) updatedRoute(oldObj, newObj interface{}) {
+	oldU := oldObj.(*unstructured.Unstructured)
+
+	oldHost, _, _ := unstructured.NestedString(oldU.UnstructuredContent(), "spec", "host")
+	newU := newObj.(*unstructured.Unstructured)
+	newHost, _, _ := unstructured.NestedString(newU.UnstructuredContent(), "spec", "host")
+
+	if oldHost != newHost {
+		klog.InfoS("Updating route host", "oldHost", oldHost, "newHost", newHost)
+		c.unexposeHost(oldHost)
+		c.exposeHost(newHost)
+	}
+}
+
+func (c *MicroShiftmDNSController) deletedRoute(obj interface{}) {
+	u := obj.(*unstructured.Unstructured)
+	host, found, err := unstructured.NestedString(u.UnstructuredContent(), "spec", "host")
+	if !found || err != nil {
+		klog.ErrorS(err, "mDNS spec.host not found")
+		return
+	}
+
+	c.unexposeHost(host)
+}
+
+func (c *MicroShiftmDNSController) exposeHost(host string) {
+	if !strings.HasSuffix(host, server.DefaultmDNSTLD) {
+		klog.V(2).InfoS("mDNS ignoring host without mDNS suffix", "host", host)
+		return
+	}
+
+	klog.InfoS("mDNS: route found for", "host", host, "ips", c.myIPs)
+
+	// TODO(multi-node) look up for the exact router service Endpoints instead of assuming our own IP (ok for single-node)
+	c.incHost(host)
+	c.resolver.AddDomain(host+".", c.myIPs)
+}
+
+func (c *MicroShiftmDNSController) unexposeHost(oldHost string) {
+	if c.decHost(oldHost) == 0 {
+		klog.InfoS("mDNS removing, no more router references", "host", oldHost)
+		c.resolver.DeleteDomain(oldHost + ".")
+	}
+}
+
+func (c *MicroShiftmDNSController) incHost(name string) {
+	c.Lock()
+	defer c.Unlock()
+	c.hostCount[name]++
+}
+
+func (c *MicroShiftmDNSController) decHost(name string) int {
+	c.Lock()
+	defer c.Unlock()
+	if c.hostCount[name] > 0 {
+		c.hostCount[name]--
+	}
+	return c.hostCount[name]
+}

--- a/pkg/mdns/routes_test.go
+++ b/pkg/mdns/routes_test.go
@@ -1,0 +1,99 @@
+package mdns
+
+import (
+	"testing"
+
+	"github.com/openshift/microshift/pkg/mdns/server"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const testIP = "1.2.3.4"
+const testIPv6 = "1111::cafe:cafe"
+const testNodeName = "test-node.local"
+const testRouteHost = "test-route-host.cluster.local"
+const testRouteHost2 = "test-route-host2.cluster.local"
+
+func newTestController() *MicroShiftmDNSController {
+	return &MicroShiftmDNSController{
+		NodeIP:    testIP,
+		NodeName:  testNodeName,
+		resolver:  server.NewResolver(),
+		hostCount: make(map[string]int),
+		myIPs:     []string{testIP, testIPv6},
+	}
+}
+
+func Test_addedRoute(t *testing.T) {
+	ctl := newTestController()
+	route := &unstructured.Unstructured{Object: make(map[string]interface{})}
+	unstructured.SetNestedField(route.Object, testRouteHost, "spec", "host")
+
+	ctl.addedRoute(route)
+	if !ctl.resolver.HasDomain(testRouteHost + ".") {
+		t.Errorf("When a host is added, the mDNS resolver should expose it")
+	}
+}
+
+func Test_deletedRoute(t *testing.T) {
+	ctl := newTestController()
+	route := &unstructured.Unstructured{Object: make(map[string]interface{})}
+
+	unstructured.SetNestedField(route.Object, testRouteHost, "spec", "host")
+	ctl.addedRoute(route)
+	ctl.addedRoute(route)
+	ctl.deletedRoute(route)
+	if !ctl.resolver.HasDomain(testRouteHost + ".") {
+		t.Errorf("When multiple routes share a hostname, deleting one route shouldn't stop exposing the host")
+	}
+
+	ctl.deletedRoute(route)
+	if ctl.resolver.HasDomain(testRouteHost + ".") {
+		t.Errorf("Deleting all routes exposing a hostname should stop exposing the host")
+	}
+}
+
+func Test_updatedRoute(t *testing.T) {
+	ctl := newTestController()
+	routeOld := &unstructured.Unstructured{Object: make(map[string]interface{})}
+	unstructured.SetNestedField(routeOld.Object, testRouteHost, "spec", "host")
+
+	routeNew := &unstructured.Unstructured{Object: make(map[string]interface{})}
+	unstructured.SetNestedField(routeNew.Object, testRouteHost2, "spec", "host")
+
+	ctl.addedRoute(routeOld)
+	ctl.updatedRoute(routeOld, routeNew)
+
+	if ctl.resolver.HasDomain(testRouteHost + ".") {
+		t.Errorf("Old domain must have updated")
+	}
+
+	if !ctl.resolver.HasDomain(testRouteHost2 + ".") {
+		t.Errorf("The updated domain must resolve at this point")
+	}
+}
+
+func Test_updatedRouteDupHost(t *testing.T) {
+	ctl := newTestController()
+	routeOld := &unstructured.Unstructured{Object: make(map[string]interface{})}
+	unstructured.SetNestedField(routeOld.Object, testRouteHost, "spec", "host")
+
+	routeNew := &unstructured.Unstructured{Object: make(map[string]interface{})}
+	unstructured.SetNestedField(routeNew.Object, testRouteHost2, "spec", "host")
+
+	ctl.addedRoute(routeOld)
+	ctl.addedRoute(routeOld) // two routes with the same hostname
+	ctl.updatedRoute(routeOld, routeNew)
+
+	if !ctl.resolver.HasDomain(testRouteHost + ".") {
+		t.Errorf("Old domain must have persisted, there is another route using it")
+	}
+
+	if !ctl.resolver.HasDomain(testRouteHost2 + ".") {
+		t.Errorf("The updated domain must resolve at this point")
+	}
+
+	ctl.deletedRoute(routeOld) // deleted the second route we had with the host
+	if ctl.resolver.HasDomain(testRouteHost + ".") {
+		t.Errorf("Old domain must have be gone after deleting the 2nd route")
+	}
+}

--- a/pkg/mdns/server/resolver.go
+++ b/pkg/mdns/server/resolver.go
@@ -1,0 +1,122 @@
+/*
+Copyright © 2021 Microshift Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package server
+
+import (
+	"net"
+	"sync"
+
+	"github.com/miekg/dns"
+)
+
+const defaultTTL = 120
+
+type Resolver struct {
+	sync.Mutex
+	domain map[string][]net.IP
+}
+
+func NewResolver() *Resolver {
+	return &Resolver{
+		domain: map[string][]net.IP{},
+	}
+}
+
+func (r *Resolver) AddDomain(name string, ipStrs []string) {
+	r.Lock()
+	defer r.Unlock()
+	var ips []net.IP
+
+	for _, ip := range ipStrs {
+		ips = append(ips, net.ParseIP(ip))
+	}
+	r.domain[name] = ips
+}
+
+func (r *Resolver) DeleteDomain(name string) {
+	r.Lock()
+	defer r.Unlock()
+	delete(r.domain, name)
+}
+
+func (r *Resolver) HasDomain(name string) bool {
+	r.Lock()
+	defer r.Unlock()
+	_, ok := r.domain[name]
+	return ok
+}
+
+func (r *Resolver) Answer(q dns.Question) []dns.RR {
+	r.Lock()
+	defer r.Unlock()
+
+	switch q.Qtype {
+	case dns.TypeA:
+		return r.answerARecord(q.Name)
+	case dns.TypeAAAA:
+		return r.answerAAAARecord(q.Name)
+	}
+
+	return nil
+}
+
+func (r *Resolver) answerARecord(name string) (rr []dns.RR) {
+	for _, ip4 := range r.getIPs(name, net.IPv4len) {
+		rr = append(rr, &dns.A{
+			Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: defaultTTL},
+			A:   ip4,
+		})
+	}
+	return rr
+}
+
+func (r *Resolver) answerAAAARecord(name string) (rr []dns.RR) {
+	for _, ip6 := range r.getIPs(name, net.IPv6len) {
+		rr = append(rr, &dns.AAAA{
+			Hdr:  dns.RR_Header{Name: name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: defaultTTL},
+			AAAA: ip6,
+		})
+	}
+	return rr
+}
+
+func (r *Resolver) getIPs(name string, ipvlen int) []net.IP {
+	ips, ok := r.domain[name]
+	if !ok || len(ips) == 0 {
+		return nil
+	}
+
+	var filteredIps []net.IP
+
+	for _, ip := range ips {
+		switch ipvlen {
+		case net.IPv4len:
+			if ip4 := ip.To4(); ip4 != nil {
+				filteredIps = append(filteredIps, ip4)
+			}
+
+		case net.IPv6len:
+			if ip4 := ip.To4(); ip4 != nil {
+				// net.To16 will convert ipv4 addresses to ::ffff:ipv4
+				continue
+			}
+			if ip16 := ip.To16(); ip16 != nil {
+				filteredIps = append(filteredIps, ip16)
+			}
+		}
+	}
+	return filteredIps
+}

--- a/pkg/mdns/server/resolver_test.go
+++ b/pkg/mdns/server/resolver_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+const testDomain = "testdomain.local."
+const testIPv4 = "1.2.3.4"
+const testIPv6 = "2001:db8::dead:beef"
+
+const testDomain2 = "testdomain2.local."
+const testIPv4_2 = "4.5.6.7"
+const testIPv6_2 = "2001:db8::cafe:cafe"
+
+func populateResolverForTests(r *Resolver) {
+	r.AddDomain(testDomain, []string{testIPv4, testIPv6})
+	r.AddDomain(testDomain2, []string{testIPv4_2, testIPv6_2})
+}
+
+func TestResolverNoDomains(t *testing.T) {
+	r := NewResolver()
+	res := r.Answer(dns.Question{Qtype: dns.TypeA, Name: testDomain})
+	if len(res) != 0 {
+		t.Errorf("With no domains resolver should not respond, but it did: %+v", res)
+	}
+}
+
+func TestResolver_AddDomain(t *testing.T) {
+	r := NewResolver()
+	populateResolverForTests(r)
+
+	testResolverDomainTypeAddress(t, r, testDomain, dns.TypeA, testIPv4)
+	testResolverDomainTypeAddress(t, r, testDomain, dns.TypeAAAA, testIPv6)
+	testResolverDomainTypeAddress(t, r, testDomain2, dns.TypeA, testIPv4_2)
+	testResolverDomainTypeAddress(t, r, testDomain2, dns.TypeAAAA, testIPv6_2)
+}
+
+func TestResolver_HasDomain(t *testing.T) {
+	r := NewResolver()
+	populateResolverForTests(r)
+
+	if !r.HasDomain(testDomain) || !r.HasDomain(testDomain2) {
+		t.Errorf("HasDomain was false for test domains")
+	}
+}
+
+func TestResolver_DeleteDomain(t *testing.T) {
+	r := NewResolver()
+	populateResolverForTests(r)
+	r.DeleteDomain(testDomain)
+
+	res := r.Answer(dns.Question{Qtype: dns.TypeA, Name: testDomain})
+	if len(res) != 0 {
+		t.Errorf("With no domains resolver should not respond, but it did: %+v", res)
+	}
+
+}
+func testResolverDomainTypeAddress(t *testing.T, r *Resolver, name string, qtype uint16, addr string) {
+	res := r.Answer(dns.Question{Qtype: qtype, Name: name})
+
+	if len(res) != 1 {
+		t.Errorf("With one domain should respond with len 1, but instead: %+v", res)
+		return
+	}
+
+	if res[0].Header().Ttl != defaultTTL {
+		t.Errorf("Incorrect TTL")
+	}
+
+	if res[0].Header().Name != name {
+		t.Errorf("Incorrect RR domain name %s", res[0].Header().Name)
+	}
+
+	if res[0].Header().Rrtype != qtype {
+		t.Errorf("Incorrect RR type, %d", res[0].Header().Rrtype)
+	}
+
+	if res[0].Header().Class != dns.ClassINET {
+		t.Errorf("Incorrect RR class, %d", res[0].Header().Class)
+	}
+
+	if !strings.HasSuffix(res[0].String(), addr) {
+		t.Errorf("%s didn't respond with address %s", res[0], addr)
+	}
+}

--- a/pkg/mdns/server/server.go
+++ b/pkg/mdns/server/server.go
@@ -1,0 +1,150 @@
+/*
+Copyright © 2021 Microshift Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package server
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/miekg/dns"
+	"k8s.io/klog/v2"
+)
+
+const (
+	DefaultmDNSTLD = ".local"
+	ipV4MDNSAddr   = "224.0.0.251"
+	ipV6MDNSAddr   = "ff02::fb"
+	mDNSPort       = 5353
+)
+
+type Server struct {
+	iface     *net.Interface
+	responder Responder
+	listeners []*net.UDPConn
+	stopCh    chan struct{}
+}
+
+type Responder interface {
+	Answer(q dns.Question) []dns.RR
+}
+
+func New(iface *net.Interface, responder Responder, stopCh chan struct{}) (*Server, error) {
+	srv := &Server{iface: iface, stopCh: stopCh, responder: responder}
+
+	for network, ipaddr := range map[string]string{"udp4": ipV4MDNSAddr, "udp6": ipV6MDNSAddr} {
+		listener, _ := net.ListenMulticastUDP(network, iface, &net.UDPAddr{
+			IP:   net.ParseIP(ipaddr),
+			Port: mDNSPort,
+		})
+
+		if listener != nil {
+			srv.listeners = append(srv.listeners, listener)
+
+			go func() {
+				<-stopCh
+				listener.Close()
+			}()
+
+			go srv.listenerLoop(listener)
+		}
+	}
+
+	return srv, nil
+}
+
+func (s *Server) listenerLoop(c *net.UDPConn) {
+	buf := make([]byte, 65536)
+	for {
+		length, addr, err := c.ReadFromUDP(buf)
+		if length == 0 {
+			/* connection closed */
+			return
+		} else if err != nil {
+			klog.Errorf("Error receiving from udp: %s", err)
+		} else if err := s.handlemDNSPacket(c, buf[:length], addr); err != nil {
+			klog.Errorf("Error handling mdns query: %v", err)
+		}
+	}
+}
+
+func (s *Server) handlemDNSPacket(conn *net.UDPConn, packet []byte, from net.Addr) error {
+	var query dns.Msg
+	var answers []dns.RR
+	unicast := false
+
+	if err := query.Unpack(packet); err != nil {
+		return err
+	}
+	if query.Opcode != dns.OpcodeQuery || query.Rcode != 0 || query.Truncated {
+		return nil
+	}
+
+	// Handle all the questions and construct the answers
+	for _, q := range query.Question {
+		for _, a := range s.responder.Answer(q) {
+			answers = append(answers, a)
+		}
+		unicast = unicast || q.Qclass&(1<<15) != 0
+	}
+
+	// Build into a DNS packet
+	dnsMsg := &dns.Msg{
+		MsgHdr: dns.MsgHdr{
+			Id:            uint16(0),
+			Response:      true,
+			Opcode:        query.Opcode,
+			Authoritative: true,
+		},
+		Compress: true,
+		Answer:   answers,
+	}
+
+	if len(answers) == 0 {
+		return nil
+	}
+
+	if err := s.sendmDNSResponse(conn, dnsMsg, from, unicast); err != nil {
+		return fmt.Errorf("mdns: error sending response unicast=%v: %v", unicast, err)
+	}
+
+	return nil
+}
+
+func (s *Server) sendmDNSResponse(conn *net.UDPConn, resp *dns.Msg, from net.Addr, unicast bool) error {
+
+	destAddr := from.(*net.UDPAddr)
+
+	buf, err := resp.Pack()
+	if err != nil {
+		return err
+	}
+
+	if !unicast {
+		if destAddr.IP.To4() != nil {
+			destAddr.IP = net.ParseIP(ipV4MDNSAddr)
+		} else {
+			destAddr.IP = net.ParseIP(ipV6MDNSAddr)
+		}
+	}
+
+	_, err = conn.WriteToUDP(buf, destAddr)
+	if unicast {
+		return err
+	} else {
+		/* multicast sometimes fails when listening on multiple interfaces */
+		return nil
+	}
+}

--- a/pkg/mdns/server/server_test.go
+++ b/pkg/mdns/server/server_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestFunctionalServer(t *testing.T) {
+	var stopCh = make(chan struct{})
+	defer close(stopCh)
+	r := NewResolver()
+	populateResolverForTests(r)
+
+	loopbackInterface, _ := net.InterfaceByName("lo")
+	_, err := New(loopbackInterface, r, stopCh)
+	if err != nil {
+		t.Errorf("Error starting mDNS server on loopback: %q", err)
+		return
+	}
+
+	for fullHost, ips := range r.domain {
+		host := strings.TrimRight(fullHost, ".")
+		addrs, err := net.LookupHost(host)
+		if err != nil {
+			t.Errorf("Error resolving mDNS host: %q, %s", host, err)
+		}
+
+		if countIPMatches(ips, addrs) != len(ips) {
+			t.Errorf("Not all ips %+v for %q found in resolution: %+v", ips, fullHost, addrs)
+		}
+	}
+}
+
+func countIPMatches(ips []net.IP, addrs []string) int {
+	found := 0
+	for _, ip := range ips {
+		for _, addr := range addrs {
+			// resolved IPv6 come in the IP%interface format, like 2001:db8::dead:beef%lo
+			addrParts := strings.Split(addr, "%")
+			ip2 := net.ParseIP(addrParts[0])
+			if ip.Equal(ip2) {
+				found += 1
+				break
+			}
+		}
+	}
+	return found
+}

--- a/vendor/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicinformer
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamiclister"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewDynamicSharedInformerFactory constructs a new instance of dynamicSharedInformerFactory for all namespaces.
+func NewDynamicSharedInformerFactory(client dynamic.Interface, defaultResync time.Duration) DynamicSharedInformerFactory {
+	return NewFilteredDynamicSharedInformerFactory(client, defaultResync, metav1.NamespaceAll, nil)
+}
+
+// NewFilteredDynamicSharedInformerFactory constructs a new instance of dynamicSharedInformerFactory.
+// Listers obtained via this factory will be subject to the same filters as specified here.
+func NewFilteredDynamicSharedInformerFactory(client dynamic.Interface, defaultResync time.Duration, namespace string, tweakListOptions TweakListOptionsFunc) DynamicSharedInformerFactory {
+	return &dynamicSharedInformerFactory{
+		client:           client,
+		defaultResync:    defaultResync,
+		namespace:        namespace,
+		informers:        map[schema.GroupVersionResource]informers.GenericInformer{},
+		startedInformers: make(map[schema.GroupVersionResource]bool),
+		tweakListOptions: tweakListOptions,
+	}
+}
+
+type dynamicSharedInformerFactory struct {
+	client        dynamic.Interface
+	defaultResync time.Duration
+	namespace     string
+
+	lock      sync.Mutex
+	informers map[schema.GroupVersionResource]informers.GenericInformer
+	// startedInformers is used for tracking which informers have been started.
+	// This allows Start() to be called multiple times safely.
+	startedInformers map[schema.GroupVersionResource]bool
+	tweakListOptions TweakListOptionsFunc
+}
+
+var _ DynamicSharedInformerFactory = &dynamicSharedInformerFactory{}
+
+func (f *dynamicSharedInformerFactory) ForResource(gvr schema.GroupVersionResource) informers.GenericInformer {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	key := gvr
+	informer, exists := f.informers[key]
+	if exists {
+		return informer
+	}
+
+	informer = NewFilteredDynamicInformer(f.client, gvr, f.namespace, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	f.informers[key] = informer
+
+	return informer
+}
+
+// Start initializes all requested informers.
+func (f *dynamicSharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	for informerType, informer := range f.informers {
+		if !f.startedInformers[informerType] {
+			go informer.Informer().Run(stopCh)
+			f.startedInformers[informerType] = true
+		}
+	}
+}
+
+// WaitForCacheSync waits for all started informers' cache were synced.
+func (f *dynamicSharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool {
+	informers := func() map[schema.GroupVersionResource]cache.SharedIndexInformer {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+
+		informers := map[schema.GroupVersionResource]cache.SharedIndexInformer{}
+		for informerType, informer := range f.informers {
+			if f.startedInformers[informerType] {
+				informers[informerType] = informer.Informer()
+			}
+		}
+		return informers
+	}()
+
+	res := map[schema.GroupVersionResource]bool{}
+	for informType, informer := range informers {
+		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	}
+	return res
+}
+
+// NewFilteredDynamicInformer constructs a new informer for a dynamic type.
+func NewFilteredDynamicInformer(client dynamic.Interface, gvr schema.GroupVersionResource, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions TweakListOptionsFunc) informers.GenericInformer {
+	return &dynamicInformer{
+		gvr: gvr,
+		informer: cache.NewSharedIndexInformer(
+			&cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					if tweakListOptions != nil {
+						tweakListOptions(&options)
+					}
+					return client.Resource(gvr).Namespace(namespace).List(context.TODO(), options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					if tweakListOptions != nil {
+						tweakListOptions(&options)
+					}
+					return client.Resource(gvr).Namespace(namespace).Watch(context.TODO(), options)
+				},
+			},
+			&unstructured.Unstructured{},
+			resyncPeriod,
+			indexers,
+		),
+	}
+}
+
+type dynamicInformer struct {
+	informer cache.SharedIndexInformer
+	gvr      schema.GroupVersionResource
+}
+
+var _ informers.GenericInformer = &dynamicInformer{}
+
+func (d *dynamicInformer) Informer() cache.SharedIndexInformer {
+	return d.informer
+}
+
+func (d *dynamicInformer) Lister() cache.GenericLister {
+	return dynamiclister.NewRuntimeObjectShim(dynamiclister.New(d.informer.GetIndexer(), d.gvr))
+}

--- a/vendor/k8s.io/client-go/dynamic/dynamicinformer/interface.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamicinformer/interface.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicinformer
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
+)
+
+// DynamicSharedInformerFactory provides access to a shared informer and lister for dynamic client
+type DynamicSharedInformerFactory interface {
+	Start(stopCh <-chan struct{})
+	ForResource(gvr schema.GroupVersionResource) informers.GenericInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool
+}
+
+// TweakListOptionsFunc defines the signature of a helper function
+// that wants to provide more listing options to API
+type TweakListOptionsFunc func(*metav1.ListOptions)

--- a/vendor/k8s.io/client-go/dynamic/dynamiclister/interface.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamiclister/interface.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiclister
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Lister helps list resources.
+type Lister interface {
+	// List lists all resources in the indexer.
+	List(selector labels.Selector) (ret []*unstructured.Unstructured, err error)
+	// Get retrieves a resource from the indexer with the given name
+	Get(name string) (*unstructured.Unstructured, error)
+	// Namespace returns an object that can list and get resources in a given namespace.
+	Namespace(namespace string) NamespaceLister
+}
+
+// NamespaceLister helps list and get resources.
+type NamespaceLister interface {
+	// List lists all resources in the indexer for a given namespace.
+	List(selector labels.Selector) (ret []*unstructured.Unstructured, err error)
+	// Get retrieves a resource from the indexer for a given namespace and name.
+	Get(name string) (*unstructured.Unstructured, error)
+}

--- a/vendor/k8s.io/client-go/dynamic/dynamiclister/lister.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamiclister/lister.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiclister
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ Lister = &dynamicLister{}
+var _ NamespaceLister = &dynamicNamespaceLister{}
+
+// dynamicLister implements the Lister interface.
+type dynamicLister struct {
+	indexer cache.Indexer
+	gvr     schema.GroupVersionResource
+}
+
+// New returns a new Lister.
+func New(indexer cache.Indexer, gvr schema.GroupVersionResource) Lister {
+	return &dynamicLister{indexer: indexer, gvr: gvr}
+}
+
+// List lists all resources in the indexer.
+func (l *dynamicLister) List(selector labels.Selector) (ret []*unstructured.Unstructured, err error) {
+	err = cache.ListAll(l.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*unstructured.Unstructured))
+	})
+	return ret, err
+}
+
+// Get retrieves a resource from the indexer with the given name
+func (l *dynamicLister) Get(name string) (*unstructured.Unstructured, error) {
+	obj, exists, err := l.indexer.GetByKey(name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewNotFound(l.gvr.GroupResource(), name)
+	}
+	return obj.(*unstructured.Unstructured), nil
+}
+
+// Namespace returns an object that can list and get resources from a given namespace.
+func (l *dynamicLister) Namespace(namespace string) NamespaceLister {
+	return &dynamicNamespaceLister{indexer: l.indexer, namespace: namespace, gvr: l.gvr}
+}
+
+// dynamicNamespaceLister implements the NamespaceLister interface.
+type dynamicNamespaceLister struct {
+	indexer   cache.Indexer
+	namespace string
+	gvr       schema.GroupVersionResource
+}
+
+// List lists all resources in the indexer for a given namespace.
+func (l *dynamicNamespaceLister) List(selector labels.Selector) (ret []*unstructured.Unstructured, err error) {
+	err = cache.ListAllByNamespace(l.indexer, l.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*unstructured.Unstructured))
+	})
+	return ret, err
+}
+
+// Get retrieves a resource from the indexer for a given namespace and name.
+func (l *dynamicNamespaceLister) Get(name string) (*unstructured.Unstructured, error) {
+	obj, exists, err := l.indexer.GetByKey(l.namespace + "/" + name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewNotFound(l.gvr.GroupResource(), name)
+	}
+	return obj.(*unstructured.Unstructured), nil
+}

--- a/vendor/k8s.io/client-go/dynamic/dynamiclister/shim.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamiclister/shim.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiclister
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ cache.GenericLister = &dynamicListerShim{}
+var _ cache.GenericNamespaceLister = &dynamicNamespaceListerShim{}
+
+// dynamicListerShim implements the cache.GenericLister interface.
+type dynamicListerShim struct {
+	lister Lister
+}
+
+// NewRuntimeObjectShim returns a new shim for Lister.
+// It wraps Lister so that it implements cache.GenericLister interface
+func NewRuntimeObjectShim(lister Lister) cache.GenericLister {
+	return &dynamicListerShim{lister: lister}
+}
+
+// List will return all objects across namespaces
+func (s *dynamicListerShim) List(selector labels.Selector) (ret []runtime.Object, err error) {
+	objs, err := s.lister.List(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	ret = make([]runtime.Object, len(objs))
+	for index, obj := range objs {
+		ret[index] = obj
+	}
+	return ret, err
+}
+
+// Get will attempt to retrieve assuming that name==key
+func (s *dynamicListerShim) Get(name string) (runtime.Object, error) {
+	return s.lister.Get(name)
+}
+
+func (s *dynamicListerShim) ByNamespace(namespace string) cache.GenericNamespaceLister {
+	return &dynamicNamespaceListerShim{
+		namespaceLister: s.lister.Namespace(namespace),
+	}
+}
+
+// dynamicNamespaceListerShim implements the NamespaceLister interface.
+// It wraps NamespaceLister so that it implements cache.GenericNamespaceLister interface
+type dynamicNamespaceListerShim struct {
+	namespaceLister NamespaceLister
+}
+
+// List will return all objects in this namespace
+func (ns *dynamicNamespaceListerShim) List(selector labels.Selector) (ret []runtime.Object, err error) {
+	objs, err := ns.namespaceLister.List(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	ret = make([]runtime.Object, len(objs))
+	for index, obj := range objs {
+		ret[index] = obj
+	}
+	return ret, err
+}
+
+// Get will attempt to retrieve by namespace and name
+func (ns *dynamicNamespaceListerShim) Get(name string) (runtime.Object, error) {
+	return ns.namespaceLister.Get(name)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -507,6 +507,7 @@ github.com/mailru/easyjson/jwriter
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 => github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/miekg/dns v1.1.35 => github.com/miekg/dns v1.1.35
+## explicit
 github.com/miekg/dns
 # github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989 => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
 github.com/mindprince/gonvml
@@ -1908,6 +1909,8 @@ k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/discovery/cached/memory
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic
+k8s.io/client-go/dynamic/dynamicinformer
+k8s.io/client-go/dynamic/dynamiclister
 k8s.io/client-go/informers
 k8s.io/client-go/informers/admissionregistration
 k8s.io/client-go/informers/admissionregistration/v1
@@ -2241,6 +2244,7 @@ k8s.io/gengo/types
 # k8s.io/heapster v1.2.0-beta.1 => k8s.io/heapster v1.2.0-beta.1
 k8s.io/heapster/metrics/api/v1/types
 # k8s.io/klog/v2 v2.8.0 => k8s.io/klog/v2 v2.8.0
+## explicit
 k8s.io/klog/v2
 # k8s.io/kube-aggregator v0.21.0 => k8s.io/kube-aggregator v0.21.0
 ## explicit


### PR DESCRIPTION
This commit adds support in microshift do do mDNS announcement on the LAN.

1) For the host name
For example if your hostname is `microshift.locaL`, other hosts will be able to
resolve microshift.local, because microshift will respond to the name with the IPv4 and IPv6 addresses.

2) For the hosts in the routes
for example, if you have a route with the host: `nginx.cluster.local`, and another `mqtt.cluster.local` ,
microshift would respond for both with the openshift-router IP addresses, so
other services in the lan can find those services.

This is a proposal of functionality which can be tested at this point, if we believe this is useful to the project 
I can start writing tests and documenting.


Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
