### PR TITLE
git ignore rpm artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _output/*
 /microshift
+packaging/rpm/_rpmbuild/
 bin
 .idea/
 .vscode/


### PR DESCRIPTION
rpm artifacts do not belong in git history
