### PR TITLE
Sometimes the cleanup script won't clean /var/lib/microshift

### DIFF
--- a/hack/cleanup.sh
+++ b/hack/cleanup.sh
@@ -19,7 +19,6 @@ sudo bash -c '
     systemctl disable microshift-containerized 2>/dev/null
     podman stop microshift 2>/dev/null
     podman stop microshift-aio 2>/dev/null
-    set -e
 
     echo "Removing crio pods"
     until crictl rmp --all --force 1>/dev/null; do sleep 1; done


### PR DESCRIPTION
Any of the other actions could stop the script (pkill not finding
the processes already gone, etc...).

This fixes it by continuing through until deletion of the microshift
data.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
