### PR TITLE
fix for failed to get system container stats errors

### DIFF
--- a/pkg/node/kubelet.go
+++ b/pkg/node/kubelet.go
@@ -71,10 +71,6 @@ func (s *KubeletServer) configure(cfg *config.MicroshiftConfig) error {
 	args := []string{
 		"--bootstrap-kubeconfig=" + cfg.DataDir + "/resources/kubelet/kubeconfig",
 		"--kubeconfig=" + cfg.DataDir + "/resources/kubelet/kubeconfig",
-		"--container-runtime=remote",
-		"--container-runtime-endpoint=unix:///var/run/crio/crio.sock",
-		"--runtime-cgroups=/system.slice/crio.service",
-		"--node-ip=" + cfg.NodeIP,
 		"--logtostderr=" + strconv.FormatBool(cfg.LogDir == "" || cfg.LogAlsotostderr),
 		"--alsologtostderr=" + strconv.FormatBool(cfg.LogAlsotostderr),
 		"--v=" + strconv.Itoa(cfg.LogVLevel),
@@ -87,6 +83,11 @@ func (s *KubeletServer) configure(cfg *config.MicroshiftConfig) error {
 	cleanFlagSet.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 
 	kubeletFlags := kubeletoptions.NewKubeletFlags()
+	kubeletFlags.RuntimeCgroups = "/system.slice/crio.service"
+	kubeletFlags.NodeIP = cfg.NodeIP
+	kubeletFlags.ContainerRuntime = "remote"
+	kubeletFlags.RemoteRuntimeEndpoint = "unix:///var/run/crio/crio.sock"
+
 	kubeletConfig, err := loadConfigFile(cfg.DataDir + "/resources/kubelet/config/config.yaml")
 
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Parul <parsingh@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/redhat-et/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #475
This PR adds ` "/system.slice/crio.service"` to kubelet flags to suppress error message regarding 
```
"Failed to get system container stats" err="failed to get cgroup stats for \"/system.slice/crio.service\": failed to get container info for \"/system.slice/crio.service\": unknown container \"/system.slice/crio.service\"" containerName="/system.slice/crio.service"
```
