### PR TITLE
Do not modify default logging parameters

### DIFF
--- a/assets/apps/0000_70_dns_01-dns-daemonset.yaml
+++ b/assets/apps/0000_70_dns_01-dns-daemonset.yaml
@@ -62,7 +62,6 @@ spec:
       - name: kube-rbac-proxy
         image: {{ .ReleaseImage.kube_rbac_proxy }}
         args:
-        - --logtostderr
         - --secure-listen-address=:9154
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
         - --upstream=http://127.0.0.1:9153/

--- a/pkg/assets/apps/bindata.go
+++ b/pkg/assets/apps/bindata.go
@@ -328,7 +328,6 @@ spec:
       - name: kube-rbac-proxy
         image: {{ .ReleaseImage.kube_rbac_proxy }}
         args:
-        - --logtostderr
         - --secure-listen-address=:9154
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
         - --upstream=http://127.0.0.1:9153/

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -60,7 +60,7 @@ func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 	}
 
 	os.MkdirAll(cfg.DataDir, 0700)
-	os.MkdirAll(cfg.LogDir, 0700)
+	os.MkdirAll(cfg.AuditLogDir, 0700)
 
 	// TODO: change to only initialize what is strictly necessary for the selected role(s)
 	if _, err := os.Stat(filepath.Join(cfg.DataDir, "certs")); errors.Is(err, os.ErrNotExist) {

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -44,6 +44,7 @@ func NewRunMicroshiftCommand() *cobra.Command {
 	cmd.MarkFlagFilename("config", "yaml", "yml")
 	// All other flags will be read after reading both config file and env vars.
 	flags.String("data-dir", cfg.DataDir, "Directory for storing runtime data.")
+	flags.String("audit-log-dir", cfg.AuditLogDir, "Directory for storing audit logs.")
 	flags.StringSlice("roles", cfg.Roles, "Roles of this MicroShift instance.")
 
 	return cmd

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,10 +50,8 @@ type MicroshiftConfig struct {
 	ConfigFile string
 	DataDir    string `yaml:"dataDir"`
 
-	LogDir          string `yaml:"logDir"`
-	LogVLevel       int    `yaml:"logVLevel"`
-	LogVModule      string `yaml:"logVModule"`
-	LogAlsotostderr bool   `yaml:"logAlsotostderr"`
+	LogDir    string `yaml:"logDir"`
+	LogVLevel int    `yaml:"logVLevel"`
 
 	Roles []string `yaml:"roles"`
 
@@ -76,15 +74,13 @@ func NewMicroshiftConfig() *MicroshiftConfig {
 	}
 
 	return &MicroshiftConfig{
-		ConfigFile:      findConfigFile(),
-		DataDir:         findDataDir(),
-		LogDir:          "/var/log/microshift/",
-		LogVLevel:       0,
-		LogVModule:      "",
-		LogAlsotostderr: false,
-		Roles:           defaultRoles,
-		NodeName:        nodeName,
-		NodeIP:          nodeIP,
+		ConfigFile: findConfigFile(),
+		DataDir:    findDataDir(),
+		LogDir:     "/var/log/microshift/",
+		LogVLevel:  0,
+		Roles:      defaultRoles,
+		NodeName:   nodeName,
+		NodeIP:     nodeIP,
 		Cluster: ClusterConfig{
 			URL:         "https://127.0.0.1:6443",
 			ClusterCIDR: "10.42.0.0/16",
@@ -183,12 +179,6 @@ func (c *MicroshiftConfig) ReadFromCmdLine(flags *pflag.FlagSet) error {
 	if vLevelFlag := flags.Lookup("v"); vLevelFlag != nil && flags.Changed("v") {
 		c.LogVLevel, _ = strconv.Atoi(vLevelFlag.Value.String())
 	}
-	if vModuleFlag := flags.Lookup("vmodule"); vModuleFlag != nil && flags.Changed("vmodule") {
-		c.LogVModule = vModuleFlag.Value.String()
-	}
-	if alsologtostderr, err := flags.GetBool("alsologtostderr"); err == nil && flags.Changed("alsologtostderr") {
-		c.LogAlsotostderr = alsologtostderr
-	}
 	if roles, err := flags.GetStringSlice("roles"); err == nil && flags.Changed("roles") {
 		c.Roles = roles
 	}
@@ -219,13 +209,12 @@ func InitGlobalFlags() {
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 
 	goflag.CommandLine.VisitAll(func(goflag *goflag.Flag) {
-		if StringInList(goflag.Name, []string{"v", "vmodule", "log_dir", "log_file", "alsologtostderr", "logtostderr"}) {
+		if StringInList(goflag.Name, []string{"v", "log_dir", "log_file"}) {
 			pflag.CommandLine.AddGoFlag(goflag)
 		}
 	})
 
 	pflag.CommandLine.MarkHidden("log-flush-frequency")
 	pflag.CommandLine.MarkHidden("log_file")
-	pflag.CommandLine.MarkHidden("logtostderr")
 	pflag.CommandLine.MarkHidden("version")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,8 +50,8 @@ type MicroshiftConfig struct {
 	ConfigFile string
 	DataDir    string `yaml:"dataDir"`
 
-	LogDir    string `yaml:"logDir"`
-	LogVLevel int    `yaml:"logVLevel"`
+	AuditLogDir string `yaml:"auditLogDir"`
+	LogVLevel   int    `yaml:"logVLevel"`
 
 	Roles []string `yaml:"roles"`
 
@@ -74,13 +74,13 @@ func NewMicroshiftConfig() *MicroshiftConfig {
 	}
 
 	return &MicroshiftConfig{
-		ConfigFile: findConfigFile(),
-		DataDir:    findDataDir(),
-		LogDir:     "/var/log/microshift/",
-		LogVLevel:  0,
-		Roles:      defaultRoles,
-		NodeName:   nodeName,
-		NodeIP:     nodeIP,
+		ConfigFile:  findConfigFile(),
+		DataDir:     findDataDir(),
+		AuditLogDir: "/var/log/microshift/",
+		LogVLevel:   0,
+		Roles:       defaultRoles,
+		NodeName:    nodeName,
+		NodeIP:      nodeIP,
 		Cluster: ClusterConfig{
 			URL:         "https://127.0.0.1:6443",
 			ClusterCIDR: "10.42.0.0/16",
@@ -173,8 +173,8 @@ func (c *MicroshiftConfig) ReadFromCmdLine(flags *pflag.FlagSet) error {
 	if dataDir, err := flags.GetString("data-dir"); err == nil && flags.Changed("data-dir") {
 		c.DataDir = dataDir
 	}
-	if logDir, err := flags.GetString("log-dir"); err == nil && flags.Changed("log-dir") {
-		c.LogDir = logDir
+	if auditLogDir, err := flags.GetString("audit-log-dir"); err == nil && flags.Changed("audit-log-dir") {
+		c.AuditLogDir = auditLogDir
 	}
 	if vLevelFlag := flags.Lookup("v"); vLevelFlag != nil && flags.Changed("v") {
 		c.LogVLevel, _ = strconv.Atoi(vLevelFlag.Value.String())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,7 +76,7 @@ func NewMicroshiftConfig() *MicroshiftConfig {
 	return &MicroshiftConfig{
 		ConfigFile:  findConfigFile(),
 		DataDir:     findDataDir(),
-		AuditLogDir: "/var/log/microshift/",
+		AuditLogDir: "",
 		LogVLevel:   0,
 		Roles:       defaultRoles,
 		NodeName:    nodeName,
@@ -209,7 +209,7 @@ func InitGlobalFlags() {
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 
 	goflag.CommandLine.VisitAll(func(goflag *goflag.Flag) {
-		if StringInList(goflag.Name, []string{"v", "log_dir", "log_file"}) {
+		if StringInList(goflag.Name, []string{"v", "log_file"}) {
 			pflag.CommandLine.AddGoFlag(goflag)
 		}
 	})

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -39,14 +39,12 @@ func TestCommandLineConfig(t *testing.T) {
 	}{
 		{
 			config: &MicroshiftConfig{
-				DataDir:         "/tmp/microshift/data",
-				LogDir:          "/tmp/microshift/logs",
-				LogVLevel:       4,
-				LogVModule:      "microshift=4",
-				LogAlsotostderr: true,
-				Roles:           []string{"controlplane", "node"},
-				NodeName:        "node1",
-				NodeIP:          "1.2.3.4",
+				DataDir:   "/tmp/microshift/data",
+				LogDir:    "/tmp/microshift/logs",
+				LogVLevel: 4,
+				Roles:     []string{"controlplane", "node"},
+				NodeName:  "node1",
+				NodeIP:    "1.2.3.4",
 				Cluster: ClusterConfig{
 					URL:         "https://1.2.3.4:6443",
 					ClusterCIDR: "10.20.30.40/16",
@@ -66,8 +64,6 @@ func TestCommandLineConfig(t *testing.T) {
 		flags.StringVar(&config.DataDir, "data-dir", "", "")
 		flags.StringVar(&config.LogDir, "log-dir", "", "")
 		flags.IntVar(&config.LogVLevel, "v", 0, "")
-		flags.StringVar(&config.LogVModule, "vmodule", "", "")
-		flags.BoolVar(&config.LogAlsotostderr, "alsologtostderr", false, "")
 		flags.StringSliceVar(&config.Roles, "roles", []string{}, "")
 		flags.StringVar(&config.NodeName, "node-name", "", "")
 		flags.StringVar(&config.NodeIP, "node-ip", "", "")
@@ -82,8 +78,6 @@ func TestCommandLineConfig(t *testing.T) {
 			"--data-dir=" + tt.config.DataDir,
 			"--log-dir=" + tt.config.LogDir,
 			"--v=" + strconv.Itoa(tt.config.LogVLevel),
-			"--vmodule=" + tt.config.LogVModule,
-			"--alsologtostderr",
 			"--roles=" + strings.Join(tt.config.Roles, ","),
 			"--node-name=" + tt.config.NodeName,
 			"--node-ip=" + tt.config.NodeIP,
@@ -118,15 +112,13 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 	}{
 		{
 			desiredMicroShiftConfig: &MicroshiftConfig{
-				ConfigFile:      "/to/config/file",
-				DataDir:         "/tmp/microshift/data",
-				LogDir:          "/tmp/microshift/logs",
-				LogVLevel:       23,
-				LogVModule:      "microshift=23",
-				LogAlsotostderr: true,
-				Roles:           []string{"controlplane", "node"},
-				NodeName:        "node1",
-				NodeIP:          "1.2.3.4",
+				ConfigFile: "/to/config/file",
+				DataDir:    "/tmp/microshift/data",
+				LogDir:     "/tmp/microshift/logs",
+				LogVLevel:  23,
+				Roles:      []string{"controlplane", "node"},
+				NodeName:   "node1",
+				NodeIP:     "1.2.3.4",
 				Cluster: ClusterConfig{
 					URL:         "https://cluster.com:4343/endpoint",
 					ClusterCIDR: "10.20.30.40/16",
@@ -144,8 +136,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 				{"MICROSHIFT_DATADIR", "/tmp/microshift/data"},
 				{"MICROSHIFT_LOGDIR", "/tmp/microshift/logs"},
 				{"MICROSHIFT_LOGVLEVEL", "23"},
-				{"MICROSHIFT_LOGVMODULE", "microshift=23"},
-				{"MICROSHIFT_LOGALSOTOSTDERR", "true"},
 				{"MICROSHIFT_ROLES", "controlplane,node"},
 				{"MICROSHIFT_NODENAME", "node1"},
 				{"MICROSHIFT_NODEIP", "1.2.3.4"},
@@ -182,8 +172,6 @@ func TestMicroshiftConfigReadAndValidate(t *testing.T) {
 	flags.String("data-dir", "", "")
 	flags.String("log-dir", "", "")
 	flags.Int("v", 0, "")
-	flags.String("vmodule", "", "")
-	flags.Bool("alsologtostderr", false, "")
 	flags.StringSlice("roles", []string{}, "")
 
 	c := NewMicroshiftConfig()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -39,12 +39,12 @@ func TestCommandLineConfig(t *testing.T) {
 	}{
 		{
 			config: &MicroshiftConfig{
-				DataDir:   "/tmp/microshift/data",
-				LogDir:    "/tmp/microshift/logs",
-				LogVLevel: 4,
-				Roles:     []string{"controlplane", "node"},
-				NodeName:  "node1",
-				NodeIP:    "1.2.3.4",
+				DataDir:     "/tmp/microshift/data",
+				AuditLogDir: "/tmp/microshift/logs",
+				LogVLevel:   4,
+				Roles:       []string{"controlplane", "node"},
+				NodeName:    "node1",
+				NodeIP:      "1.2.3.4",
 				Cluster: ClusterConfig{
 					URL:         "https://1.2.3.4:6443",
 					ClusterCIDR: "10.20.30.40/16",
@@ -62,7 +62,7 @@ func TestCommandLineConfig(t *testing.T) {
 		// bind the flags to the config
 		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 		flags.StringVar(&config.DataDir, "data-dir", "", "")
-		flags.StringVar(&config.LogDir, "log-dir", "", "")
+		flags.StringVar(&config.AuditLogDir, "audit-log-dir", "", "")
 		flags.IntVar(&config.LogVLevel, "v", 0, "")
 		flags.StringSliceVar(&config.Roles, "roles", []string{}, "")
 		flags.StringVar(&config.NodeName, "node-name", "", "")
@@ -76,7 +76,7 @@ func TestCommandLineConfig(t *testing.T) {
 		// parse the flags
 		flags.Parse([]string{
 			"--data-dir=" + tt.config.DataDir,
-			"--log-dir=" + tt.config.LogDir,
+			"--audit-log-dir=" + tt.config.AuditLogDir,
 			"--v=" + strconv.Itoa(tt.config.LogVLevel),
 			"--roles=" + strings.Join(tt.config.Roles, ","),
 			"--node-name=" + tt.config.NodeName,
@@ -112,13 +112,13 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 	}{
 		{
 			desiredMicroShiftConfig: &MicroshiftConfig{
-				ConfigFile: "/to/config/file",
-				DataDir:    "/tmp/microshift/data",
-				LogDir:     "/tmp/microshift/logs",
-				LogVLevel:  23,
-				Roles:      []string{"controlplane", "node"},
-				NodeName:   "node1",
-				NodeIP:     "1.2.3.4",
+				ConfigFile:  "/to/config/file",
+				DataDir:     "/tmp/microshift/data",
+				AuditLogDir: "/tmp/microshift/logs",
+				LogVLevel:   23,
+				Roles:       []string{"controlplane", "node"},
+				NodeName:    "node1",
+				NodeIP:      "1.2.3.4",
 				Cluster: ClusterConfig{
 					URL:         "https://cluster.com:4343/endpoint",
 					ClusterCIDR: "10.20.30.40/16",
@@ -134,7 +134,7 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 			}{
 				{"MICROSHIFT_CONFIGFILE", "/to/config/file"},
 				{"MICROSHIFT_DATADIR", "/tmp/microshift/data"},
-				{"MICROSHIFT_LOGDIR", "/tmp/microshift/logs"},
+				{"MICROSHIFT_AUDITLOGDIR", "/tmp/microshift/logs"},
 				{"MICROSHIFT_LOGVLEVEL", "23"},
 				{"MICROSHIFT_ROLES", "controlplane,node"},
 				{"MICROSHIFT_NODENAME", "node1"},
@@ -170,7 +170,7 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 func TestMicroshiftConfigReadAndValidate(t *testing.T) {
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	flags.String("data-dir", "", "")
-	flags.String("log-dir", "", "")
+	flags.String("audit-log-dir", "", "")
 	flags.Int("v", 0, "")
 	flags.StringSlice("roles", []string{}, "")
 

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -115,14 +115,11 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) {
 		"--tls-cert-file=" + cfg.DataDir + "/certs/kube-apiserver/secrets/service-network-serving-certkey/tls.crt",
 		"--tls-private-key-file=" + cfg.DataDir + "/certs/kube-apiserver/secrets/service-network-serving-certkey/tls.key",
 		"--cors-allowed-origins=/127.0.0.1(:[0-9]+)?$,/localhost(:[0-9]+)?$",
-		"--logtostderr=" + strconv.FormatBool(cfg.LogDir == "" || cfg.LogAlsotostderr),
-		"--alsologtostderr=" + strconv.FormatBool(cfg.LogAlsotostderr),
 		"--v=" + strconv.Itoa(cfg.LogVLevel),
 		"--vmodule=" + cfg.LogVModule,
 	}
 	if cfg.LogDir != "" {
 		args = append(args,
-			"--log-file="+filepath.Join(cfg.LogDir, "kube-apiserver.log"),
 			"--audit-log-path="+filepath.Join(cfg.LogDir, "kube-apiserver-audit.log"))
 	}
 

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -115,8 +114,6 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) {
 		"--tls-cert-file=" + cfg.DataDir + "/certs/kube-apiserver/secrets/service-network-serving-certkey/tls.crt",
 		"--tls-private-key-file=" + cfg.DataDir + "/certs/kube-apiserver/secrets/service-network-serving-certkey/tls.key",
 		"--cors-allowed-origins=/127.0.0.1(:[0-9]+)?$,/localhost(:[0-9]+)?$",
-		"--v=" + strconv.Itoa(cfg.LogVLevel),
-		"--vmodule=" + cfg.LogVModule,
 	}
 	if cfg.LogDir != "" {
 		args = append(args,

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -115,9 +115,9 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) {
 		"--tls-private-key-file=" + cfg.DataDir + "/certs/kube-apiserver/secrets/service-network-serving-certkey/tls.key",
 		"--cors-allowed-origins=/127.0.0.1(:[0-9]+)?$,/localhost(:[0-9]+)?$",
 	}
-	if cfg.LogDir != "" {
+	if cfg.AuditLogDir != "" {
 		args = append(args,
-			"--audit-log-path="+filepath.Join(cfg.LogDir, "kube-apiserver-audit.log"))
+			"--audit-log-path="+filepath.Join(cfg.AuditLogDir, "kube-apiserver-audit.log"))
 	}
 
 	// fake the kube-apiserver cobra command to parse args into serverOptions

--- a/pkg/controllers/kube-controller-manager.go
+++ b/pkg/controllers/kube-controller-manager.go
@@ -71,13 +71,8 @@ func (s *KubeControllerManager) configure(cfg *config.MicroshiftConfig) {
 		"--use-service-account-credentials=true",
 		"--cluster-signing-cert-file=" + caCertFile,
 		"--cluster-signing-key-file=" + cfg.DataDir + "/certs/ca-bundle/ca-bundle.key",
-		"--logtostderr=" + strconv.FormatBool(cfg.LogDir == "" || cfg.LogAlsotostderr),
-		"--alsologtostderr=" + strconv.FormatBool(cfg.LogAlsotostderr),
 		"--v=" + strconv.Itoa(cfg.LogVLevel),
 		"--vmodule=" + cfg.LogVModule,
-	}
-	if cfg.LogDir != "" {
-		args = append(args, "--log-file="+filepath.Join(cfg.LogDir, "kube-controller-manager.log"))
 	}
 
 	// fake the kube-controller-manager cobra command to parse args into controllermanager options

--- a/pkg/controllers/kube-controller-manager.go
+++ b/pkg/controllers/kube-controller-manager.go
@@ -18,7 +18,6 @@ package controllers
 import (
 	"context"
 	"path/filepath"
-	"strconv"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -71,8 +70,6 @@ func (s *KubeControllerManager) configure(cfg *config.MicroshiftConfig) {
 		"--use-service-account-credentials=true",
 		"--cluster-signing-cert-file=" + caCertFile,
 		"--cluster-signing-key-file=" + cfg.DataDir + "/certs/ca-bundle/ca-bundle.key",
-		"--v=" + strconv.Itoa(cfg.LogVLevel),
-		"--vmodule=" + cfg.LogVModule,
 	}
 
 	// fake the kube-controller-manager cobra command to parse args into controllermanager options

--- a/pkg/controllers/kube-scheduler.go
+++ b/pkg/controllers/kube-scheduler.go
@@ -61,14 +61,8 @@ func (s *KubeScheduler) configure(cfg *config.MicroshiftConfig) {
 
 	args := []string{
 		"--config=" + cfg.DataDir + "/resources/kube-scheduler/config/config.yaml",
-		"--logtostderr=" + strconv.FormatBool(cfg.LogDir == "" || cfg.LogAlsotostderr),
-		"--alsologtostderr=" + strconv.FormatBool(cfg.LogAlsotostderr),
 		"--v=" + strconv.Itoa(cfg.LogVLevel),
 		"--vmodule=" + cfg.LogVModule,
-	}
-
-	if cfg.LogDir != "" {
-		args = append(args, "--log-file="+filepath.Join(cfg.LogDir, "kube-scheduler.log"))
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/controllers/kube-scheduler.go
+++ b/pkg/controllers/kube-scheduler.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/openshift/microshift/pkg/config"
 	"github.com/openshift/microshift/pkg/util"
@@ -61,8 +60,6 @@ func (s *KubeScheduler) configure(cfg *config.MicroshiftConfig) {
 
 	args := []string{
 		"--config=" + cfg.DataDir + "/resources/kube-scheduler/config/config.yaml",
-		"--v=" + strconv.Itoa(cfg.LogVLevel),
-		"--vmodule=" + cfg.LogVModule,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/controllers/openshift-apiserver.go
+++ b/pkg/controllers/openshift-apiserver.go
@@ -62,10 +62,8 @@ func (s *OCPAPIServer) configure(cfg *config.MicroshiftConfig) error {
 	}
 	args := []string{
 		"--config=" + configFilePath,
-		"--alsologtostderr=" + strconv.FormatBool(cfg.LogAlsotostderr),
 		"--v=" + strconv.Itoa(cfg.LogVLevel),
 		"--vmodule=" + cfg.LogVModule,
-		"--logtostderr=" + strconv.FormatBool(cfg.LogDir == "" || cfg.LogAlsotostderr),
 	}
 
 	options := openshift_apiserver.OpenShiftAPIServer{

--- a/pkg/controllers/openshift-apiserver.go
+++ b/pkg/controllers/openshift-apiserver.go
@@ -225,14 +225,17 @@ apiServerArguments:
   - Scope
   - SystemMasters
   - RBAC
-  - Node
+  - Node`)
+
+	if cfg.AuditLogDir != "" {
+		data = append(data, `
 auditConfig:
-  auditFilePath: "` + cfg.AuditLogDir + `/openshift-apiserver/audit.log"
+  auditFilePath: `+cfg.AuditLogDir+`openshift-apiserver-audit.log
   enabled: true
   logFormat: json
   maximumFileSizeMegabytes: 100
   maximumRetainedFiles: 10
-  policyFile: "` + cfg.DataDir + `/resources/openshift-apiserver/config/policy.yaml"
+  policyFile: "`+cfg.DataDir+`/resources/openshift-apiserver/config/policy.yaml"
   policyConfiguration:
     apiVersion: audit.k8s.io/v1
     kind: Policy
@@ -260,25 +263,28 @@ auditConfig:
       - system:unauthenticated
     - level: Metadata
       omitStages:
-      - RequestReceived
+      - RequestReceived`...)
+	}
+
+	data = append(data, `
 imagePolicyConfig:
   internalRegistryHostname: image-registry.openshift-image-registry.svc:5000
 projectConfig:
   projectRequestMessage: ''
 routingConfig:
-  subdomain: ` + cfg.Cluster.Domain + `
+  subdomain: `+cfg.Cluster.Domain+`
 servingInfo:
   bindAddress: "0.0.0.0:8444"
-  certFile: ` + cfg.DataDir + `/resources/openshift-apiserver/secrets/tls.crt
-  keyFile: ` + cfg.DataDir + `/resources/openshift-apiserver/secrets/tls.key
-  ca: ` + cfg.DataDir + `/certs/ca-bundle/ca-bundle.crt
+  certFile: `+cfg.DataDir+`/resources/openshift-apiserver/secrets/tls.crt
+  keyFile: `+cfg.DataDir+`/resources/openshift-apiserver/secrets/tls.key
+  ca: `+cfg.DataDir+`/certs/ca-bundle/ca-bundle.crt
 storageConfig:
   urls:
   - https://127.0.0.1:2379
-  certFile: ` + cfg.DataDir + `/resources/kube-apiserver/secrets/etcd-client/tls.crt
-  keyFile: ` + cfg.DataDir + `/resources/kube-apiserver/secrets/etcd-client/tls.key
-  ca: ` + cfg.DataDir + `/certs/ca-bundle/ca-bundle.crt
-  `)
+  certFile: `+cfg.DataDir+`/resources/kube-apiserver/secrets/etcd-client/tls.crt
+  keyFile: `+cfg.DataDir+`/resources/kube-apiserver/secrets/etcd-client/tls.key
+  ca: `+cfg.DataDir+`/certs/ca-bundle/ca-bundle.crt
+  `...)
 
 	path := filepath.Join(cfg.DataDir, "resources", "openshift-apiserver", "config", "config.yaml")
 	os.MkdirAll(filepath.Dir(path), os.FileMode(0755))

--- a/pkg/controllers/openshift-apiserver.go
+++ b/pkg/controllers/openshift-apiserver.go
@@ -227,7 +227,7 @@ apiServerArguments:
   - RBAC
   - Node
 auditConfig:
-  auditFilePath: "` + cfg.LogDir + `/openshift-apiserver/audit.log"
+  auditFilePath: "` + cfg.AuditLogDir + `/openshift-apiserver/audit.log"
   enabled: true
   logFormat: json
   maximumFileSizeMegabytes: 100

--- a/pkg/controllers/openshift-apiserver.go
+++ b/pkg/controllers/openshift-apiserver.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -62,8 +61,6 @@ func (s *OCPAPIServer) configure(cfg *config.MicroshiftConfig) error {
 	}
 	args := []string{
 		"--config=" + configFilePath,
-		"--v=" + strconv.Itoa(cfg.LogVLevel),
-		"--vmodule=" + cfg.LogVModule,
 	}
 
 	options := openshift_apiserver.OpenShiftAPIServer{

--- a/pkg/node/kube-proxy.go
+++ b/pkg/node/kube-proxy.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -53,10 +52,8 @@ func (s *ProxyOptions) configure(cfg *config.MicroshiftConfig) {
 	if err := s.writeConfig(cfg); err != nil {
 		logrus.Fatalf("Failed to write kube-proxy config: %v", err)
 	}
-	args := []string{
-		"--v=" + strconv.Itoa(cfg.LogVLevel),
-		"--vmodule=" + cfg.LogVModule,
-	}
+	// Keeping the args in case something must be added in the future
+	args := []string{""}
 	cmd := &cobra.Command{
 		Use:          componentKubeProxy,
 		Long:         componentKubeProxy,

--- a/pkg/node/kube-proxy.go
+++ b/pkg/node/kube-proxy.go
@@ -54,8 +54,6 @@ func (s *ProxyOptions) configure(cfg *config.MicroshiftConfig) {
 		logrus.Fatalf("Failed to write kube-proxy config: %v", err)
 	}
 	args := []string{
-		"--logtostderr=" + strconv.FormatBool(cfg.LogDir == "" || cfg.LogAlsotostderr),
-		"--alsologtostderr=" + strconv.FormatBool(cfg.LogAlsotostderr),
 		"--v=" + strconv.Itoa(cfg.LogVLevel),
 		"--vmodule=" + cfg.LogVModule,
 	}
@@ -64,9 +62,6 @@ func (s *ProxyOptions) configure(cfg *config.MicroshiftConfig) {
 		Long:         componentKubeProxy,
 		SilenceUsage: true,
 		RunE:         func(cmd *cobra.Command, args []string) error { return nil },
-	}
-	if cfg.LogDir != "" {
-		args = append(args, "--log-file="+filepath.Join(cfg.LogDir, "kube-proxy.log"))
 	}
 
 	opts := kubeproxy.NewOptions()

--- a/pkg/node/kube-proxy.go
+++ b/pkg/node/kube-proxy.go
@@ -53,7 +53,7 @@ func (s *ProxyOptions) configure(cfg *config.MicroshiftConfig) {
 		logrus.Fatalf("Failed to write kube-proxy config: %v", err)
 	}
 	// Keeping the args in case something must be added in the future
-	args := []string{""}
+	args := []string{}
 	cmd := &cobra.Command{
 		Use:          componentKubeProxy,
 		Long:         componentKubeProxy,

--- a/pkg/node/kubelet.go
+++ b/pkg/node/kubelet.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -71,8 +70,6 @@ func (s *KubeletServer) configure(cfg *config.MicroshiftConfig) {
 	args := []string{
 		"--bootstrap-kubeconfig=" + cfg.DataDir + "/resources/kubelet/kubeconfig",
 		"--kubeconfig=" + cfg.DataDir + "/resources/kubelet/kubeconfig",
-		"--v=" + strconv.Itoa(cfg.LogVLevel),
-		"--vmodule=" + cfg.LogVModule,
 	}
 	cleanFlagSet := pflag.NewFlagSet(componentKubelet, pflag.ContinueOnError)
 	cleanFlagSet.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)

--- a/pkg/node/kubelet.go
+++ b/pkg/node/kubelet.go
@@ -71,13 +71,8 @@ func (s *KubeletServer) configure(cfg *config.MicroshiftConfig) {
 	args := []string{
 		"--bootstrap-kubeconfig=" + cfg.DataDir + "/resources/kubelet/kubeconfig",
 		"--kubeconfig=" + cfg.DataDir + "/resources/kubelet/kubeconfig",
-		"--logtostderr=" + strconv.FormatBool(cfg.LogDir == "" || cfg.LogAlsotostderr),
-		"--alsologtostderr=" + strconv.FormatBool(cfg.LogAlsotostderr),
 		"--v=" + strconv.Itoa(cfg.LogVLevel),
 		"--vmodule=" + cfg.LogVModule,
-	}
-	if cfg.LogDir != "" {
-		args = append(args, "--log-file="+filepath.Join(cfg.LogDir, "kubelet.log"))
 	}
 	cleanFlagSet := pflag.NewFlagSet(componentKubelet, pflag.ContinueOnError)
 	cleanFlagSet.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -2,8 +2,6 @@
 dataDir: /tmp/microshift/data
 auditLogDir: /tmp/microshift/logs
 logVLevel: 4
-logVModule: microshift=4
-logAlsotostderr: true
 roles:
   - role1
   - role2

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,6 +1,6 @@
 --- 
 dataDir: /tmp/microshift/data
-logDir: /tmp/microshift/logs
+auditLogDir: /tmp/microshift/logs
 logVLevel: 4
 logVModule: microshift=4
 logAlsotostderr: true


### PR DESCRIPTION
klog is a singleton library, and since we use that library from all
our services in a single process setting different log files won't
work, and will syphon all logs into the last log file we add.

Keep the simple strategy of letting all output to stderr for now.

Related-Issue: #493

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
