### PR TITLE
ocp components simplify,clarify names

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -73,11 +73,11 @@ func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 		util.Must(m.AddService(controllers.NewKubeScheduler(cfg)))
 		util.Must(m.AddService(controllers.NewKubeControllerManager(cfg)))
 		util.Must(m.AddService(controllers.NewOpenShiftControllerManager(cfg)))
-		util.Must(m.AddService(controllers.NewOpenShiftPrepJob(cfg)))
+		util.Must(m.AddService(controllers.NewOpenShiftCRDManager(cfg)))
 		util.Must(m.AddService(controllers.NewOpenShiftAPIServer(cfg)))
 		util.Must(m.AddService(controllers.NewOpenShiftOAuth(cfg)))
 
-		util.Must(m.AddService(controllers.NewOpenShiftAPIComponents(cfg)))
+		util.Must(m.AddService(controllers.NewOpenShiftDefaultSCCManager(cfg)))
 		util.Must(m.AddService(mdns.NewMicroShiftmDNSController(cfg)))
 		util.Must(m.AddService(controllers.NewInfrastructureServices(cfg)))
 		util.Must(m.AddService(kustomize.NewKustomizer(cfg)))

--- a/pkg/components/controllers.go
+++ b/pkg/components/controllers.go
@@ -91,7 +91,7 @@ func startServiceCAController(cfg *config.MicroshiftConfig, kubeconfigPath strin
 		logrus.Warningf("failed to apply sa %v: %v", cm, err)
 		return err
 	}
-	if err := assets.ApplyDeployments(apps, renderSCController, assets.RenderParams{"ConfigMap": cmName, "Secret": secretName}, kubeconfigPath); err != nil {
+	if err := assets.ApplyDeployments(apps, renderServiceCAController, assets.RenderParams{"ConfigMap": cmName, "Secret": secretName}, kubeconfigPath); err != nil {
 		logrus.Warningf("failed to apply apps %v: %v", apps, err)
 		return err
 	}

--- a/pkg/components/render.go
+++ b/pkg/components/render.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/microshift/pkg/release"
 )
 
-func renderSCController(b []byte, p assets.RenderParams) ([]byte, error) {
+func renderServiceCAController(b []byte, p assets.RenderParams) ([]byte, error) {
 	data := struct {
 		ReleaseImage           assets.RenderParams
 		CAConfigMap, TLSSecret string

--- a/pkg/controllers/apiservice.go
+++ b/pkg/controllers/apiservice.go
@@ -195,7 +195,8 @@ func createAPIRegistration(cfg *config.MicroshiftConfig) error {
 	return nil
 }
 
-func applySCCs(kubeconfigPath string) error {
+func ApplyDefaultSCCs(cfg *config.MicroshiftConfig) error {
+	kubeconfigPath := cfg.DataDir + "/resources/kubeadmin/kubeconfig"
 	var (
 		sccs = []string{
 			"assets/scc/0000_20_kube-apiserver-operator_00_scc-anyuid.yaml",
@@ -208,28 +209,6 @@ func applySCCs(kubeconfigPath string) error {
 		}
 	)
 	if err := assets.ApplySCCs(sccs, nil, nil, kubeconfigPath); err != nil {
-		logrus.Warningf("failed to apply sccs: %v", err)
-		return err
-	}
-	return nil
-}
-
-func PrepareOCP(cfg *config.MicroshiftConfig) error {
-	if err := assets.ApplyNamespaces([]string{
-		"assets/core/0000_50_cluster-openshift-controller-manager_00_namespace.yaml",
-	}, cfg.DataDir+"/resources/kubeadmin/kubeconfig"); err != nil {
-		logrus.Warningf("failed to apply openshift namespaces %v", err)
-		return err
-	}
-	if err := assets.ApplyCRDs(cfg); err != nil {
-		logrus.Warningf("failed to apply openshift CRDs %v", err)
-		return err
-	}
-	return nil
-}
-
-func StartOCPAPIComponents(cfg *config.MicroshiftConfig) error {
-	if err := applySCCs(cfg.DataDir + "/resources/kubeadmin/kubeconfig"); err != nil {
 		logrus.Warningf("failed to apply sccs: %v", err)
 		return err
 	}

--- a/pkg/controllers/infra-services-controller.go
+++ b/pkg/controllers/infra-services-controller.go
@@ -36,7 +36,7 @@ func NewInfrastructureServices(cfg *config.MicroshiftConfig) *InfrastructureServ
 
 func (s *InfrastructureServicesManager) Name() string { return "infrastructure-services-manager" }
 func (s *InfrastructureServicesManager) Dependencies() []string {
-	return []string{"kube-apiserver", "openshift-prepjob-manager", "oauth-apiserver", "openshift-controller-manager"}
+	return []string{"kube-apiserver", "openshift-crd-manager", "oauth-apiserver", "openshift-controller-manager"}
 }
 
 func (s *InfrastructureServicesManager) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {

--- a/pkg/controllers/openshift-apiserver.go
+++ b/pkg/controllers/openshift-apiserver.go
@@ -50,7 +50,7 @@ func NewOpenShiftAPIServer(cfg *config.MicroshiftConfig) *OCPAPIServer {
 
 func (s *OCPAPIServer) Name() string { return "ocp-apiserver" }
 func (s *OCPAPIServer) Dependencies() []string {
-	return []string{"kube-apiserver", "openshift-prepjob-manager"}
+	return []string{"kube-apiserver", "openshift-crd-manager"}
 }
 
 func (s *OCPAPIServer) configure(cfg *config.MicroshiftConfig) error {
@@ -92,6 +92,7 @@ func (s *OCPAPIServer) configure(cfg *config.MicroshiftConfig) error {
 	s.options = options
 	s.options.ConfigFile = configFilePath
 
+	logrus.Infof("starting openshift-apiserver %s, args: %v", cfg.NodeIP, args)
 	return nil
 
 }

--- a/pkg/controllers/openshift-controller-manager.go
+++ b/pkg/controllers/openshift-controller-manager.go
@@ -27,6 +27,7 @@ import (
 
 	openshift_controller_manager "github.com/openshift/openshift-controller-manager/pkg/cmd/openshift-controller-manager"
 
+	"github.com/openshift/microshift/pkg/assets"
 	"github.com/openshift/microshift/pkg/config"
 	"github.com/openshift/microshift/pkg/util"
 )
@@ -79,6 +80,12 @@ func (s *OCPControllerManager) configure(cfg *config.MicroshiftConfig) error {
 	s.ConfigFilePath = options.ConfigFilePath
 	s.Output = options.Output
 
+	if err := assets.ApplyNamespaces([]string{
+		"assets/core/0000_50_cluster-openshift-controller-manager_00_namespace.yaml",
+	}, cfg.DataDir+"/resources/kubeadmin/kubeconfig"); err != nil {
+		logrus.Warningf("failed to apply openshift namespaces %v", err)
+		return err
+	}
 	return nil
 }
 

--- a/pkg/controllers/openshift-crd-manager.go
+++ b/pkg/controllers/openshift-crd-manager.go
@@ -18,33 +18,34 @@ package controllers
 import (
 	"context"
 
+	"github.com/openshift/microshift/pkg/assets"
 	"github.com/openshift/microshift/pkg/config"
 
 	"github.com/sirupsen/logrus"
 )
 
-type OCPPrepJobManager struct {
+type OpenShiftCRDManager struct {
 	cfg *config.MicroshiftConfig
 }
 
-func NewOpenShiftPrepJob(cfg *config.MicroshiftConfig) *OCPPrepJobManager {
-	s := &OCPPrepJobManager{}
+func NewOpenShiftCRDManager(cfg *config.MicroshiftConfig) *OpenShiftCRDManager {
+	s := &OpenShiftCRDManager{}
 	s.cfg = cfg
 	return s
 }
 
-func (s *OCPPrepJobManager) Name() string { return "openshift-prepjob-manager" }
-func (s *OCPPrepJobManager) Dependencies() []string {
+func (s *OpenShiftCRDManager) Name() string { return "openshift-crd-manager" }
+func (s *OpenShiftCRDManager) Dependencies() []string {
 	return []string{"kube-apiserver"}
 }
 
-func (s *OCPPrepJobManager) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {
+func (s *OpenShiftCRDManager) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {
 	defer close(ready)
 	// To-DO add readiness check
-	if err := PrepareOCP(s.cfg); err != nil {
-		logrus.Errorf("%s unable to prepare ocp componets: %v", s.Name(), err)
+	if err := assets.ApplyCRDs(s.cfg); err != nil {
+		logrus.Errorf("%s unable to apply default CRDs: %v", s.Name(), err)
 	}
-	logrus.Infof("%s launched ocp componets", s.Name())
+	logrus.Infof("%s applied default CRDs", s.Name())
 
 	return ctx.Err()
 }

--- a/pkg/controllers/openshift-default-scc-manager.go
+++ b/pkg/controllers/openshift-default-scc-manager.go
@@ -23,29 +23,29 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type OpenShiftAPIComponentsControllerManager struct {
+type OpenShiftDefaultSCCManager struct {
 	cfg *config.MicroshiftConfig
 }
 
-func NewOpenShiftAPIComponents(cfg *config.MicroshiftConfig) *OpenShiftAPIComponentsControllerManager {
-	s := &OpenShiftAPIComponentsControllerManager{}
+func NewOpenShiftDefaultSCCManager(cfg *config.MicroshiftConfig) *OpenShiftDefaultSCCManager {
+	s := &OpenShiftDefaultSCCManager{}
 	s.cfg = cfg
 	return s
 }
 
-func (s *OpenShiftAPIComponentsControllerManager) Name() string {
-	return "openshift-api-components-manager"
+func (s *OpenShiftDefaultSCCManager) Name() string {
+	return "openshift-default-scc-manager"
 }
-func (s *OpenShiftAPIComponentsControllerManager) Dependencies() []string {
-	return []string{"kube-apiserver", "openshift-prepjob-manager", "oauth-apiserver"}
+func (s *OpenShiftDefaultSCCManager) Dependencies() []string {
+	return []string{"kube-apiserver", "openshift-crd-manager", "oauth-apiserver"}
 }
 
-func (s *OpenShiftAPIComponentsControllerManager) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {
+func (s *OpenShiftDefaultSCCManager) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {
 	defer close(ready)
 	// TO-DO add readiness check
-	if err := StartOCPAPIComponents(s.cfg); err != nil {
-		logrus.Errorf("%s unable to prepare ocp componets: %v", s.Name(), err)
+	if err := ApplyDefaultSCCs(s.cfg); err != nil {
+		logrus.Errorf("%s unable to apply default SCCs: %v", s.Name(), err)
 	}
-	logrus.Infof("%s launched ocp componets", s.Name())
+	logrus.Infof("%s applied default SCCs", s.Name())
 	return ctx.Err()
 }

--- a/pkg/mdns/controller.go
+++ b/pkg/mdns/controller.go
@@ -34,7 +34,7 @@ func NewMicroShiftmDNSController(cfg *config.MicroshiftConfig) *MicroShiftmDNSCo
 
 func (s *MicroShiftmDNSController) Name() string { return "microshift-mdns-controller" }
 func (s *MicroShiftmDNSController) Dependencies() []string {
-	return []string{"openshift-api-components-manager"}
+	return []string{"openshift-default-scc-manager"}
 }
 
 func (c *MicroShiftmDNSController) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {

--- a/pkg/mdns/routes.go
+++ b/pkg/mdns/routes.go
@@ -60,7 +60,7 @@ func (c *MicroShiftmDNSController) run(stopCh chan struct{}, dc dynamic.Interfac
 	return nil
 }
 
-// TODO: The need for this indicates that the openshift-api-components-manager is declaring itself ready before
+// TODO: The need for this indicates that the openshift-default-scc-manager is declaring itself ready before
 //       it really is. If we don't wait for the route API the informer will start throwing ugly errors.
 func (c *MicroShiftmDNSController) waitForRouterAPI(dc dynamic.Interface, routersGVR *schema.GroupVersionResource) {
 	backoff := wait.Backoff{


### PR DESCRIPTION
Signed-off-by: Sally O'Malley <somalley@redhat.com>

PR to update names of PrepJob, APIComponents service managers, files, and functions to describe what they do:
```
NewOpenShiftPrepJob  ->  NewOpenShiftCRDManager
NewOpenShiftAPIComponents  ->  NewOpenShiftDefaultSCCManager

move openshift-controller-manager namespace creation to the StartOCM configure function
```
Closes #<Issue Number>
