### PR TITLE
Reload existing CA from disk on restart

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -21,7 +21,6 @@ import (
 	"github.com/openshift/microshift/pkg/config"
 	"github.com/openshift/microshift/pkg/controllers"
 	"github.com/openshift/microshift/pkg/util"
-
 	ctrl "k8s.io/kubernetes/pkg/controlplane"
 )
 
@@ -40,6 +39,10 @@ func initAll(cfg *config.MicroshiftConfig) error {
 	}
 
 	return nil
+}
+
+func loadCA(cfg *config.MicroshiftConfig) error {
+	return util.LoadRootCA(cfg.DataDir+"/certs/ca-bundle", "ca-bundle.crt", "ca-bundle.key")
 }
 
 func initCerts(cfg *config.MicroshiftConfig) error {

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -64,6 +65,15 @@ func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 	// TODO: change to only initialize what is strictly necessary for the selected role(s)
 	if _, err := os.Stat(filepath.Join(cfg.DataDir, "certs")); errors.Is(err, os.ErrNotExist) {
 		initAll(cfg)
+	} else {
+		err = loadCA(cfg)
+		if err != nil {
+			err := os.RemoveAll(filepath.Join(cfg.DataDir, "certs"))
+			if err != nil {
+				klog.ErrorS(err, "removing old certs directory")
+			}
+			util.Must(initAll(cfg))
+		}
 	}
 
 	m := servicemanager.NewServiceManager()


### PR DESCRIPTION
Without reloading any later operation will result in a panic
trying to access nil rootCA or nil rootKey.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
