### PR TITLE
no longer require glibc-static

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -42,7 +42,6 @@ ExclusiveArch: x86_64 aarch64 ppc64le s390x
 %endif
 
 BuildRequires: gcc
-BuildRequires: glibc-static
 BuildRequires: golang >= %{golang_version}
 BuildRequires: make
 BuildRequires: policycoreutils


### PR DESCRIPTION
glibc-static is no longer required for building the microshift RPM
