### PR TITLE
microshift-aio image builds: bump oc download in aio image for aarch64 binary

### DIFF
--- a/packaging/images/microshift-aio/Dockerfile
+++ b/packaging/images/microshift-aio/Dockerfile
@@ -42,8 +42,9 @@ COPY $BUILD_PATH/unit /usr/lib/systemd/system/microshift.service
 COPY $BUILD_PATH/kubelet-cgroups.conf /etc/systemd/system.conf.d/kubelet-cgroups.conf
 COPY $BUILD_PATH/crio-bridge.conf /etc/cni/net.d/100-crio-bridge.conf
 
-RUN export OCP_VERSION=4.8.9 && \
-    curl -o oc.tar.gz https://mirror2.openshift.com/pub/openshift-v4/amd64/clients/ocp/$OCP_VERSION/openshift-client-linux-$OCP_VERSION.tar.gz && \
+# OCP_VERSION pushed ahead to 4.9.11 because aarch64 is now available, and it is backwards compatible
+RUN export OCP_VERSION=4.9.11 && \
+    curl -o oc.tar.gz https://mirror2.openshift.com/pub/openshift-v4/$ARCH/clients/ocp/$OCP_VERSION/openshift-client-linux-$OCP_VERSION.tar.gz && \
     tar -xzvf oc.tar.gz && \
     rm oc.tar.gz && \
     install -t /usr/local/bin {kubectl,oc}


### PR DESCRIPTION
Signed-off-by: Sally O'Malley <somalley@redhat.com>

For microshift-aio image builds, the aarch64 oc binary is available as of 4.9.11 - rather than hardcoding the version to 4.8, and for amd64, bump the version and add $ARCH instead

Note: oc version will temporarily be ahead of component versions atm (4.8), but it is backwards compatible.

/cc @thinkahead
