### PR TITLE
Prevent crio from wiring pods until the CNI is ready

### DIFF
--- a/packaging/crio.conf.d/microshift.conf
+++ b/packaging/crio.conf.d/microshift.conf
@@ -1,0 +1,4 @@
+[crio.network]
+# cbr0 is the name configured by flannel in /etc/cni/net.d/ config file
+# by declaring this crio will wait until that network is configured.
+cni_default_network = "cbr0"

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -177,6 +177,9 @@ install -p -m755 hack/cleanup.sh %{buildroot}%{_bindir}/cleanup-all-microshift-d
 
 restorecon -v %{buildroot}%{_bindir}/microshift
 
+install -d -m755 %{buildroot}%{_sysconfdir}/crio/crio.conf.d
+install -p -m644 packaging/crio.conf.d/microshift.conf %{buildroot}%{_sysconfdir}/crio/crio.conf.d/microshift.conf
+
 install -d -m755 %{buildroot}/%{_unitdir}
 install -p -m644 packaging/systemd/microshift.service %{buildroot}%{_unitdir}/microshift.service
 install -p -m644 packaging/systemd/microshift-containerized.service %{buildroot}%{_unitdir}/microshift-containerized.service
@@ -194,6 +197,12 @@ install -m644 packaging/selinux/microshift.pp.bz2 %{buildroot}%{_datadir}/selinu
 %post
 
 %systemd_post microshift.service
+
+# only for install, not on upgrades
+if [ $1 -eq 1 ]; then
+	# if crio was already started, restart it so it will catch /etc/crio/crio.conf.d/microshift.conf
+	systemctl is-active --quiet crio && systemctl restart --quiet crio
+fi
 
 %post selinux
 
@@ -220,6 +229,7 @@ fi
 %{_bindir}/microshift
 %{_bindir}/cleanup-all-microshift-data
 %{_unitdir}/microshift.service
+%{_sysconfdir}/crio/crio.conf.d/microshift.conf
 
 %files selinux
 


### PR DESCRIPTION
cbr0 is the network name configured by flannel, the kubelet
will not schedule pods, and won't be ready until the CNI
configures properly the host.

This avoids host provisioner or service-ca from failing
on first start sometimes.

Fixes-Issue: #356

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
