### PR TITLE
Support crio.networks in rhel8 properly

### DIFF
--- a/packaging/crio.conf.d/microshift.conf
+++ b/packaging/crio.conf.d/microshift.conf
@@ -2,3 +2,9 @@
 # cbr0 is the name configured by flannel in /etc/cni/net.d/ config file
 # by declaring this crio will wait until that network is configured.
 cni_default_network = "cbr0"
+
+# rhel8 crio is configured to only look at /usr/libexec/cni, we override that here
+plugin_dirs = [
+        "/usr/libexec/cni",
+        "/opt/cni/bin"
+]


### PR DESCRIPTION
Add the /opt/cni/bin directory to the search path

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
