### PR TITLE
add script to run dlv with the microshift binary

### DIFF
--- a/hack/runDlv.sh
+++ b/hack/runDlv.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+DLV=$HOME/go/bin/dlv
+[[ -x $DLV ]] || \
+  sudo dnf install -y golang &&
+  go install github.com/go-delve/delve/cmd/dlv@latest
+
+sudo systemctl kill microshift
+sudo systemctl disable --now microshift
+sudo systemctl kill microshift
+sudo firewall-cmd --zone=public --add-port=2345/tcp --permanent
+sudo firewall-cmd --reload
+sudo $DLV --listen=:2345 --headless --api-version=2 --accept-multiclient exec /usr/bin/microshift -- run

--- a/hack/runDlv.sh
+++ b/hack/runDlv.sh
@@ -6,7 +6,6 @@ DLV=$HOME/go/bin/dlv
 
 sudo systemctl kill microshift
 sudo systemctl disable --now microshift
-sudo systemctl kill microshift
 sudo firewall-cmd --zone=public --add-port=2345/tcp --permanent
 sudo firewall-cmd --reload
 sudo $DLV --listen=:2345 --headless --api-version=2 --accept-multiclient exec /usr/bin/microshift -- run


### PR DESCRIPTION
This is helpful to run the delve debugger in a remote host (or locally)
and then connect from your favorite IDE or delve instance for
remote debugging.
