### PR TITLE
WIP: Add ipwatch controller to handle IP address changes

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -11,6 +11,7 @@ import (
 	"github.com/coreos/go-systemd/daemon"
 	"github.com/openshift/microshift/pkg/config"
 	"github.com/openshift/microshift/pkg/controllers"
+	"github.com/openshift/microshift/pkg/ipwatch"
 	"github.com/openshift/microshift/pkg/kustomize"
 	"github.com/openshift/microshift/pkg/mdns"
 	"github.com/openshift/microshift/pkg/node"
@@ -114,6 +115,8 @@ func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 		util.Must(m.AddService(node.NewKubeletServer(cfg)))
 		util.Must(m.AddService(node.NewKubeProxyServer(cfg)))
 	}
+
+	util.Must(m.AddService(ipwatch.NewIPWatchController(cfg)))
 
 	logrus.Info("Starting MicroShift")
 

--- a/pkg/ipwatch/ipwatch.go
+++ b/pkg/ipwatch/ipwatch.go
@@ -1,0 +1,70 @@
+/*
+Copyright © 2022 Microshift Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipwatch
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/openshift/microshift/pkg/config"
+	"github.com/openshift/microshift/pkg/util"
+	"k8s.io/klog/v2"
+)
+
+const ipCheckInterval = time.Second * 5
+
+type IPWatchController struct {
+	NodeIP string
+	stopCh chan struct{}
+}
+
+func NewIPWatchController(cfg *config.MicroshiftConfig) *IPWatchController {
+	return &IPWatchController{
+		NodeIP: cfg.NodeIP,
+	}
+}
+
+func (s *IPWatchController) Name() string { return "ipwatch-controller" }
+func (s *IPWatchController) Dependencies() []string {
+	return []string{}
+}
+
+func (c *IPWatchController) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {
+	defer close(stopped)
+	ticker := time.NewTicker(ipCheckInterval)
+	defer ticker.Stop()
+
+	klog.Infof("Starting ipwatch-controller with IP address %q", c.NodeIP)
+
+	for {
+		select {
+		case <-ticker.C:
+			currentIP, _ := util.GetHostIP()
+			if c.NodeIP != currentIP {
+				// using a harsh exit for now since soft kill ends in a loop of trying to contact etcd
+				// syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+				klog.Warningf("IP address has changed from %q to %q, restarting MicroShift", c.NodeIP, currentIP)
+				os.Exit(1)
+				return nil
+			}
+
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}


### PR DESCRIPTION
The IPWatchController will restart MicroShift when IP address
changes have been detected.

This is an initial implementation which will trigger the initialization
of all components with the new IP address and relies on systemd or
podman restarting the process.

Related-Issue: #556

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
