### PR TITLE
force packaging versions

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -14,6 +14,10 @@
 
 # SELinux specifics
 %global selinuxtype targeted
+%define selinux_policyver 3.14.3-67
+%define container_policyver 2.167.0-1
+%define container_policy_epoch 2
+
 
 # Git related details
 %global shortcommit %(c=%{git_commit}; echo ${c:0:7})
@@ -118,9 +122,9 @@ restorecon -R /var/hpvolumes
 
 %package selinux
 Summary: SELinux policies for MicroShift
-BuildRequires: selinux-policy
-BuildRequires: selinux-policy-devel
-Requires: container-selinux
+BuildRequires: selinux-policy >= %{selinux_policyver}
+BuildRequires: selinux-policy-devel >= %{selinux_policyver}
+Requires: container-selinux >= %{container_policy_epoch}:%{container_policyver}
 BuildArch: noarch
 %{?selinux_requires}
 

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -259,6 +259,9 @@ mv /usr/lib/systemd/system/microshift-containerized.service /usr/lib/systemd/sys
 %{_unitdir}/microshift-containerized.service
 
 %changelog
+* Wed Feb 2 2022 Ryan Cook <rcook@redhat.com> . 4.8.0-nightly-14-g8a3819ee
+- Define specific selinux policy version to help manage selinux package
+
 * Thu Nov 4 2021 Miguel angel Ajo <majopela@redhat.com> . 4.8.0-nightly-14-g973b9c78
 - Add microshift-containerized subpackage which contains the microshift-containerized systemd
   definition.


### PR DESCRIPTION
Signed-off-by: Ryan Cook <rcook@redhat.com>

Force set versions.

Output RHEL 8 
```
Total                                                          79 MB/s |  36 MB     00:00     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                      1/1 
  Installing       : microshift-selinux-4.8.0-2022_01_04_175420_24_g8a3819ee.el8.noarch   1/2 
  Running scriptlet: microshift-selinux-4.8.0-2022_01_04_175420_24_g8a3819ee.el8.noarch   1/2 
  Installing       : microshift-4.8.0-2022_01_04_175420_24_g8a3819ee.el8.x86_64           2/2 
  Running scriptlet: microshift-4.8.0-2022_01_04_175420_24_g8a3819ee.el8.x86_64           2/2 
  Running scriptlet: microshift-selinux-4.8.0-2022_01_04_175420_24_g8a3819ee.el8.noarch   2/2 
  Running scriptlet: microshift-4.8.0-2022_01_04_175420_24_g8a3819ee.el8.x86_64           2/2 
  Verifying        : microshift-4.8.0-2022_01_04_175420_24_g8a3819ee.el8.x86_64           1/2 
  Verifying        : microshift-selinux-4.8.0-2022_01_04_175420_24_g8a3819ee.el8.noarch   2/2 
Installed products updated.

Installed:
  microshift-4.8.0-2022_01_04_175420_24_g8a3819ee.el8.x86_64                                  
  microshift-selinux-4.8.0-2022_01_04_175420_24_g8a3819ee.el8.noarch                          

Complete!
```

Output Fedora 35 
```
Importing GPG key 0x26DF568C:
 Userid     : "cooktheryan_microshift (None) <cooktheryan#microshift@copr.fedorahosted.org>"
 Fingerprint: 6075 9B78 E731 4E58 7E4F E878 AA94 B3E7 26DF 568C
 From       : https://download.copr.fedorainfracloud.org/results/cooktheryan/microshift/pubkey.gpg
Is this ok [y/N]: y
Key imported successfully
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                             1/1 
  Installing       : microshift-selinux-4.8.0-2022_01_04_175420_24_g8a3819ee.fc35.noarch                         1/2 
  Running scriptlet: microshift-selinux-4.8.0-2022_01_04_175420_24_g8a3819ee.fc35.noarch                         1/2 
libsemanage.semanage_direct_install_info: A higher priority microshift module exists at priority 400 and will override the module currently being installed at priority 200.

  Installing       : microshift-4.8.0-2022_01_04_175420_24_g8a3819ee.fc35.x86_64                                 2/2 
  Running scriptlet: microshift-4.8.0-2022_01_04_175420_24_g8a3819ee.fc35.x86_64                                 2/2 
Removed /etc/systemd/system/multi-user.target.wants/microshift.service.

  Running scriptlet: microshift-selinux-4.8.0-2022_01_04_175420_24_g8a3819ee.fc35.noarch                         2/2 
  Running scriptlet: microshift-4.8.0-2022_01_04_175420_24_g8a3819ee.fc35.x86_64                                 2/2 
  Verifying        : microshift-4.8.0-2022_01_04_175420_24_g8a3819ee.fc35.x86_64                                 1/2 
  Verifying        : microshift-selinux-4.8.0-2022_01_04_175420_24_g8a3819ee.fc35.noarch                         2/2 

Installed:
  microshift-4.8.0-2022_01_04_175420_24_g8a3819ee.fc35.x86_64                                                        
  microshift-selinux-4.8.0-2022_01_04_175420_24_g8a3819ee.fc35.noarch                                                

Complete!
```
Closes #473 
