### PR TITLE
Bot token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,4 +29,4 @@ jobs:
         shell: bash
         run: make release TOKEN=${GITHUB_TOKEN}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Due to how we are doing releases + copr release we cannot use the default github account 

```When you use the repository's GITHUB_TOKEN to perform tasks on behalf of the GitHub Actions app, events triggered by the GITHUB_TOKEN will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.```

An account was generated. It will need permissions to be a member of the project with a secret loaded.