### PR TITLE
Install /etc/crio/crio.conf.d for containerized MicroShift

### DIFF
--- a/packaging/images/microshift/Dockerfile
+++ b/packaging/images/microshift/Dockerfile
@@ -29,7 +29,12 @@ RUN microdnf install -y \
     && microdnf clean all
 COPY --from=builder /opt/app-root/src/github.com/redhat-et/microshift/_output/bin/linux_$ARCH/microshift /usr/bin/microshift
 
-ENTRYPOINT ["/usr/bin/microshift"]
+RUN mkdir -p /root/crio.conf.d
+
+COPY packaging/crio.conf.d/microshift.conf /root/crio.conf.d/microshift.conf
+COPY packaging/images/microshift/entrypoint.sh /root/entrypoint.sh
+
+ENTRYPOINT ["/root/entrypoint.sh"]
 CMD ["run"]
 
 # To start:

--- a/packaging/images/microshift/entrypoint.sh
+++ b/packaging/images/microshift/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+mkdir -p /etc/crio/crio.conf.d
+cp /root/crio.conf.d/microshift.conf /etc/crio/crio.conf.d/microshift.conf
+
+# switch to microshift process
+exec /usr/bin/microshift run

--- a/packaging/systemd/microshift-containerized.service
+++ b/packaging/systemd/microshift-containerized.service
@@ -15,7 +15,7 @@ Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/usr/bin/mkdir -p /var/lib/kubelet ; /usr/bin/mkdir -p /var/hpvolumes
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
-ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --replace --sdnotify=container --label io.containers.autoupdate=registry --network=host --privileged -d --name microshift -v /var/hpvolumes:/var/hpvolumes:z,rw,rshared -v /var/run/crio/crio.sock:/var/run/crio/crio.sock:rw,rshared -v microshift-data:/var/lib/microshift:rw,rshared -v /var/lib/kubelet:/var/lib/kubelet:z,rw,rshared -v /var/log:/var/log quay.io/microshift/microshift:latest
+ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --replace --sdnotify=container --label io.containers.autoupdate=registry --network=host --privileged -d --name microshift -v /var/hpvolumes:/var/hpvolumes:z,rw,rshared -v /var/run/crio/crio.sock:/var/run/crio/crio.sock:rw,rshared -v microshift-data:/var/lib/microshift:rw,rshared -v /var/lib/kubelet:/var/lib/kubelet:z,rw,rshared -v /var/log:/var/log -v /etc:/etc quay.io/microshift/microshift:latest
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 Type=notify


### PR DESCRIPTION
Otherwise some containers start before the flannel setup is
ready. This configuration guarantees that MicroShift.

Fixes-Issue: #605

Signed-off-by: Miguel Angel Ajo Pelayo <miguelangel@ajo.es>

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/redhat-et/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #605
