### PR TITLE
Specify the right pause image used by cri-o

### DIFF
--- a/pkg/release/release_amd64.go
+++ b/pkg/release/release_amd64.go
@@ -28,7 +28,7 @@ func init() {
 		"kube_flannel_cni":              "quay.io/microshift/flannel-cni:" + Base,
 		"kube_rbac_proxy":               "quay.io/openshift/okd-content@sha256:459f15f0e457edaf04fa1a44be6858044d9af4de276620df46dc91a565ddb4ec",
 		"kubevirt_hostpath_provisioner": "quay.io/kubevirt/hostpath-provisioner:v0.8.0",
-		"pause":                         "k8s.gcr.io/pause",
+		"pause":                         "k8s.gcr.io/pause:3.2",
 		"service_ca_operator":           "quay.io/openshift/okd-content@sha256:dd1cd4d7b1f2d097eaa965bc5e2fe7ebfe333d6cbaeabc7879283af1a88dbf4e",
 	}
 }


### PR DESCRIPTION
Otherwise the later container rpm-packaging patches
will grab the wrong image, and the pause image is missing
for offline systems.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
