### PR TITLE
Pack containers into GitHub CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Install required packages
-        run: sudo apt-get update && sudo apt install build-essential qemu-user qemu-user-static 
+        run: sudo apt-get update && sudo apt install build-essential qemu-user qemu-user-static podman
       
       - name: Checkout source
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,14 @@ build-containerized-all-in-one-iptables-arm64:
 .PHONY: build-containerized-all-in-one-iptables-arm64
 
 ###############################
+# container image packaging   #
+###############################
+
+image-tars:
+	sudo ./packaging/images/components/archive.sh
+.PHONY: image-tars
+
+###############################
 # dev targets                 #
 ###############################
 

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ build-containerized-all-in-one-iptables-arm64:
 # container image packaging   #
 ###############################
 
-image-tars:
+tar-ocp-containers:
 	sudo ./packaging/images/components/archive.sh
 .PHONY: image-tars
 

--- a/packaging/images/components/archive.sh
+++ b/packaging/images/components/archive.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+get="${SCRIPT_DIR}/../../../pkg/release/get.sh"
+
+ARCHITECTURES=${ARCHITECTURES:-"arm64 amd64"}
+BASE_VERSION=${BASE_VERSION:-$("${get}" base)}
+OUTPUT_DIR=${OUTPUT_DIR:-$(pwd)/archive}
+
+TMP_DIR=$(mktemp -d)
+
+mkdir -p "${OUTPUT_DIR}"
+chmod a+rwx "${OUTPUT_DIR}"
+
+for arch in $ARCHITECTURES; do
+    images=$("${get}" images $arch)
+    storage="${TMP_DIR}/${arch}/containers"
+    mkdir -p "${storage}"
+    echo "Pulling images for architecture ${arch} ==================="
+    for image in $images; do
+        echo pulling $image @$arch
+        # some imported images are armhfp instead of arm
+        podman pull --arch $arch --root "${storage}" "${image}"
+        if [ $? -ne 0 ]; then
+            if [ "${arch}" == "arm" ];  then
+                echo "Fallback arm -> armhfp"
+                podman pull --arch armhfp --root "${TMP_DIR}/${arch}" "${image}" || exit 1
+            else
+                echo "Couldn't pull image ${image} for ${arch}"
+                exit 1
+            fi
+        fi
+    done
+
+    echo ""
+    echo "Packing tarball for architecture ${arch} =================="
+    pushd ${storage}
+    output_file="${OUTPUT_DIR}/microshift-containers-${BASE_VERSION}-${arch}.tar.bz2"
+    echo " >  ${output_file}"
+    tar cfj "${OUTPUT_DIR}/microshift-containers-${BASE_VERSION}-${arch}.tar.bz2" .
+    chmod a+rw "${OUTPUT_DIR}/microshift-containers-${BASE_VERSION}-${arch}.tar.bz2"
+    popd
+    rm -rf ${storage}
+done

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -304,6 +304,9 @@ if [ $NIGHTLY -eq 1 ]; then
   exit 0
 fi
 
+# create container tar.gzs for the consumed container images for non-nightly releases
+ARCHITECTURES="amd64 arm64" OUTPUT_DIR="${STAGE_DIR}" sudo -E "${ROOT}/packaging/image/components/archive.sh" || exit 1
+
 # publish binaries
 UPLOAD_URL="$(git_create_release "$API_DATA" "$TOKEN")"                   || exit 1
 git_post_artifacts "$STAGE_DIR" "$UPLOAD_URL" "$TOKEN"                    || exit 1


### PR DESCRIPTION
These .tar.gzs later will be used by common non-podman capable builders
(copr) to create rpms with the container images.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>