### PR TITLE
Set Default Audit Log Retention

### DIFF
--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -118,6 +118,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) {
 	if cfg.AuditLogDir != "" {
 		args = append(args,
 			"--audit-log-path="+filepath.Join(cfg.AuditLogDir, "kube-apiserver-audit.log"))
+		args = append(args, "--audit-log-maxage=7")
 	}
 
 	// fake the kube-apiserver cobra command to parse args into serverOptions


### PR DESCRIPTION
If an audit log directory is provided, set the default audit log
retention age to 7 days. When `--audit-log-maxage` is not specified,
kube-apiserver audit logs are retained indefinitely, taking up
signficant space on the host node.

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/redhat-et/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #613 
