### PR TITLE
Use default GOMAXPROCS behavior

### DIFF
--- a/cmd/microshift/main.go
+++ b/cmd/microshift/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"runtime"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -23,10 +22,6 @@ func main() {
 
 	logs.InitLogs()
 	defer logs.FlushLogs()
-
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
 
 	command := newCommand()
 	if err := command.Execute(); err != nil {


### PR DESCRIPTION
Stop setting GOMAXPROCS as more recent versions of Golang already defaults to NumCPU.
Aligns with OpenShift Standalone.

see: https://pkg.go.dev/runtime#GOMAXPROCS