### PR TITLE
Add conntrack-tools dependency to rpms

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -66,6 +66,7 @@ Requires: cri-o
 Requires: cri-tools
 Requires: iptables
 Requires: microshift-selinux
+Requires: conntrack-tools
 
 %{?systemd_requires}
 


### PR DESCRIPTION
We need to check EL8/9 targets for such package being fully available
once built in copr nightly.

Signed-off-by: Miguel Angel Ajo Pelayo <miguelangel@ajo.es>
