### PR TITLE
Equalise service stop or failures

### DIFF
--- a/pkg/controllers/openshift-apiserver.go
+++ b/pkg/controllers/openshift-apiserver.go
@@ -119,11 +119,9 @@ func (s *OCPAPIServer) Run(ctx context.Context, ready chan<- struct{}, stopped c
 		return err
 	}
 
-	stopCh := make(chan struct{})
-	if err := s.options.RunAPIServer(stopCh); err != nil {
+	if err := s.options.RunAPIServer(ctx.Done()); err != nil {
 		klog.Fatalf("Failed to start ocp-apiserver %v", err)
 	}
-
 	return ctx.Err()
 }
 

--- a/pkg/controllers/openshift-oauth-server.go
+++ b/pkg/controllers/openshift-oauth-server.go
@@ -102,7 +102,6 @@ func (s *OpenShiftOAuth) configure(cfg *config.MicroshiftConfig) {
 
 func (s *OpenShiftOAuth) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {
 	defer close(stopped)
-	stopCh := make(chan struct{})
 
 	// run readiness check
 	go func() {
@@ -114,8 +113,8 @@ func (s *OpenShiftOAuth) Run(ctx context.Context, ready chan<- struct{}, stopped
 		close(ready)
 	}()
 
-	if err := oauth_apiserver.RunOAuthAPIServer(s.options, stopCh); err != nil {
-		return err
+	if err := oauth_apiserver.RunOAuthAPIServer(s.options, ctx.Done()); err != nil {
+		klog.Fatalf("Error starting oauth API server: %s", err)
 	}
 
 	return ctx.Err()

--- a/pkg/kustomize/apply.go
+++ b/pkg/kustomize/apply.go
@@ -48,7 +48,7 @@ func (s *Kustomizer) Run(ctx context.Context, ready chan<- struct{}, stopped cha
 	if _, err := os.Stat(kustomization); !errors.Is(err, os.ErrNotExist) {
 		klog.Infof("Applying kustomization at %v ", kustomization)
 		if err := ApplyKustomizationWithRetries(s.path, s.kubeconfig); err != nil {
-			klog.Warningf("Applying kustomization failed: %s. Giving up.", err)
+			klog.Fatalf("Applying kustomization failed: %s. Giving up.", err)
 		} else {
 			klog.Warningf("Kustomization applied successfully.")
 		}

--- a/pkg/node/kube-proxy.go
+++ b/pkg/node/kube-proxy.go
@@ -106,9 +106,13 @@ func (s *ProxyOptions) Run(ctx context.Context, ready chan<- struct{}, stopped c
 		klog.Infof("%s is ready", s.Name())
 		close(ready)
 	}()
-	if err := s.options.Run(); err != nil {
-		klog.Fatalf("%s failed to start", s.Name(), err)
-	}
 
+	go func() {
+		if err := s.options.Run(); err != nil {
+			klog.Fatalf("%s failed to start %v", s.Name(), err)
+		}
+	}()
+
+	<-ctx.Done()
 	return ctx.Err()
 }


### PR DESCRIPTION
This PR handles service stop/failure to make them all behave equally, and also to be able
to be stopped on request, please see individual commits.

- Make kube-proxy Service stoppable
- Exit on kustomization failure
- Make oauth-api-server stoppable and return errors
- Make ocp-api-server stoppable by manager
- Let the OpenshiftControllerManager service to be stopped
