### PR TITLE
Expose service node port range as MicroShift config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,10 +32,11 @@ var (
 type ClusterConfig struct {
 	URL string `yaml:"url"`
 
-	ClusterCIDR string `yaml:"clusterCIDR"`
-	ServiceCIDR string `yaml:"serviceCIDR"`
-	DNS         string `yaml:"dns"`
-	Domain      string `yaml:"domain"`
+	ClusterCIDR          string `yaml:"clusterCIDR"`
+	ServiceCIDR          string `yaml:"serviceCIDR"`
+	ServiceNodePortRange string `yaml:"serviceNodePortRange"`
+	DNS                  string `yaml:"dns"`
+	Domain               string `yaml:"domain"`
 }
 
 type ControlPlaneConfig struct {
@@ -82,11 +83,12 @@ func NewMicroshiftConfig() *MicroshiftConfig {
 		NodeName:    nodeName,
 		NodeIP:      nodeIP,
 		Cluster: ClusterConfig{
-			URL:         "https://127.0.0.1:6443",
-			ClusterCIDR: "10.42.0.0/16",
-			ServiceCIDR: "10.43.0.0/16",
-			DNS:         "10.43.0.10",
-			Domain:      "cluster.local",
+			URL:                  "https://127.0.0.1:6443",
+			ClusterCIDR:          "10.42.0.0/16",
+			ServiceCIDR:          "10.43.0.0/16",
+			ServiceNodePortRange: "30000-32767",
+			DNS:                  "10.43.0.10",
+			Domain:               "cluster.local",
 		},
 		ControlPlane: ControlPlaneConfig{},
 		Node:         NodeConfig{},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -46,11 +46,12 @@ func TestCommandLineConfig(t *testing.T) {
 				NodeName:    "node1",
 				NodeIP:      "1.2.3.4",
 				Cluster: ClusterConfig{
-					URL:         "https://1.2.3.4:6443",
-					ClusterCIDR: "10.20.30.40/16",
-					ServiceCIDR: "40.30.20.10/16",
-					DNS:         "cluster.dns",
-					Domain:      "cluster.local",
+					URL:                  "https://1.2.3.4:6443",
+					ClusterCIDR:          "10.20.30.40/16",
+					ServiceCIDR:          "40.30.20.10/16",
+					ServiceNodePortRange: "1024-32767",
+					DNS:                  "cluster.dns",
+					Domain:               "cluster.local",
 				},
 			},
 			err: nil,
@@ -70,6 +71,7 @@ func TestCommandLineConfig(t *testing.T) {
 		flags.StringVar(&config.Cluster.URL, "cluster-url", "", "")
 		flags.StringVar(&config.Cluster.ClusterCIDR, "cluster-cidr", "", "")
 		flags.StringVar(&config.Cluster.ServiceCIDR, "service-cidr", "", "")
+		flags.StringVar(&config.Cluster.ServiceNodePortRange, "service-node-port-range", "", "")
 		flags.StringVar(&config.Cluster.DNS, "cluster-dns", "", "")
 		flags.StringVar(&config.Cluster.Domain, "cluster-domain", "", "")
 
@@ -84,6 +86,7 @@ func TestCommandLineConfig(t *testing.T) {
 			"--cluster-url=" + tt.config.Cluster.URL,
 			"--cluster-cidr=" + tt.config.Cluster.ClusterCIDR,
 			"--service-cidr=" + tt.config.Cluster.ServiceCIDR,
+			"--service-node-port-range=" + tt.config.Cluster.ServiceNodePortRange,
 			"--cluster-dns=" + tt.config.Cluster.DNS,
 			"--cluster-domain=" + tt.config.Cluster.Domain,
 		})
@@ -120,11 +123,12 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 				NodeName:    "node1",
 				NodeIP:      "1.2.3.4",
 				Cluster: ClusterConfig{
-					URL:         "https://cluster.com:4343/endpoint",
-					ClusterCIDR: "10.20.30.40/16",
-					ServiceCIDR: "40.30.20.10/16",
-					DNS:         "10.43.0.10",
-					Domain:      "cluster.local",
+					URL:                  "https://cluster.com:4343/endpoint",
+					ClusterCIDR:          "10.20.30.40/16",
+					ServiceCIDR:          "40.30.20.10/16",
+					ServiceNodePortRange: "1024-32767",
+					DNS:                  "10.43.0.10",
+					Domain:               "cluster.local",
 				},
 			},
 			err: nil,
@@ -142,6 +146,7 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 				{"MICROSHIFT_CLUSTER_URL", "https://cluster.com:4343/endpoint"},
 				{"MICROSHIFT_CLUSTER_CLUSTERCIDR", "10.20.30.40/16"},
 				{"MICROSHIFT_CLUSTER_SERVICECIDR", "40.30.20.10/16"},
+				{"MICROSHIFT_CLUSTER_SERVICENODEPORTRANGE", "1024-32767"},
 				{"MICROSHIFT_CLUSTER_DNS", "10.43.0.10"},
 				{"MICROSHIFT_CLUSTER_DOMAIN", "cluster.local"},
 			},

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -110,6 +110,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) {
 		"--service-account-key-file=" + cfg.DataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.crt",
 		"--service-account-signing-key-file=" + cfg.DataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.key",
 		"--service-cluster-ip-range=" + cfg.Cluster.ServiceCIDR,
+		"--service-node-port-range=" + cfg.Cluster.ServiceNodePortRange,
 		"--storage-backend=etcd3",
 		"--tls-cert-file=" + cfg.DataDir + "/certs/kube-apiserver/secrets/service-network-serving-certkey/tls.crt",
 		"--tls-private-key-file=" + cfg.DataDir + "/certs/kube-apiserver/secrets/service-network-serving-certkey/tls.key",


### PR DESCRIPTION
Signed-off-by: Ricardo Noriega <rnoriega@redhat.com>

With this new parameter, service node port range can be successfully customized as a MicroShift config para:

config.yaml
```
cluster: 
  url:                  "https://127.0.0.1:6443"
  clusterCIDR:          "10.42.0.0/16"
  serviceCIDR:          "10.44.0.0/16"
  serviceNodePortRange: "1050-33000"
  dns:                  "10.44.0.10"
  domain:               "cluster.local"
```

We edit the router nodePort from 30001 to 2001:

```
[root@fedora ~] # oc get svc -A 
NAMESPACE           NAME                        TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
default             kubernetes                  ClusterIP   10.44.0.1       <none>        443/TCP                      109s
default             openshift-apiserver         ClusterIP   None            <none>        443/TCP                      68s
default             openshift-oauth-apiserver   ClusterIP   None            <none>        443/TCP                      68s
openshift-dns       dns-default                 ClusterIP   10.44.0.10      <none>        53/UDP,53/TCP,9154/TCP       57s
openshift-ingress   router-external-default     NodePort    10.44.169.17    <none>        80:30001/TCP,443:30002/TCP   57s
openshift-ingress   router-internal-default     ClusterIP   10.44.189.237   <none>        80/TCP,443/TCP,1936/TCP      57s
[root@fedora ~] # oc edit svc router-external-default -n openshift-ingress
service/router-external-default edited
[root@fedora ~] # 
[root@fedora ~] # 
[root@fedora ~] # oc get svc -A 
NAMESPACE           NAME                        TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                     AGE
default             kubernetes                  ClusterIP   10.44.0.1       <none>        443/TCP                     2m25s
default             openshift-apiserver         ClusterIP   None            <none>        443/TCP                     104s
default             openshift-oauth-apiserver   ClusterIP   None            <none>        443/TCP                     104s
openshift-dns       dns-default                 ClusterIP   10.44.0.10      <none>        53/UDP,53/TCP,9154/TCP      93s
openshift-ingress   router-external-default     NodePort    10.44.169.17    <none>        80:2001/TCP,443:30002/TCP   93s
openshift-ingress   router-internal-default     ClusterIP   10.44.189.237   <none>        80/TCP,443/TCP,1936/TCP     93s
```


Closes #648 