### PR TITLE
Do not create .build-ids in rpms for containers (paack)

### DIFF
--- a/packaging/rpm/paack.py
+++ b/packaging/rpm/paack.py
@@ -41,6 +41,7 @@ Name: %%_NAME_%%
 # disable dynamic rpmbuild checks
 %global __os_install_post /bin/true
 %global __arch_install_post /bin/true
+%global _build_id_links none
 
 AutoReqProv: no
 


### PR DESCRIPTION
rpmbuild macros otherwise create a /usr/lib/.build-id reference
to every elf file inside the containers, and those clash with
other system rpms.